### PR TITLE
fix/SNAPWOO-23: Set the correct link for upload CSV

### DIFF
--- a/js/src/pages/settings/product-catalog/index.js
+++ b/js/src/pages/settings/product-catalog/index.js
@@ -177,7 +177,7 @@ const ProductCatalog = () => {
 										<AppDocumentationLink
 											context="settings"
 											linkId="csv-learn-more"
-											href="https://tbd"
+											href="https://businesshelp.snapchat.com/s/article/manual-add-catalog?language=en_GB"
 										/>
 									),
 								}


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/SNAPWOO-23/the-upload-link-for-product-catalog-is-not-set