### PR TITLE
E2E/SNAPWOO-26: Add E2E tests for successful onboarding modal

### DIFF
--- a/tests/e2e/specs/settings.spec.js
+++ b/tests/e2e/specs/settings.spec.js
@@ -44,6 +44,37 @@ test.describe( 'Snapchat Settings', () => {
 		await settingPage.closePage();
 	} );
 
+	test( 'Can see onboarding success modal', async () => {
+		await settingPage.mockJetpackConnected();
+		await settingPage.mockSnapchatConnection( { status: 'connected' } );
+		await page.goto(
+			'/wp-admin/admin.php?page=wc-admin&path=%2Fsnapchat%2Fsetup',
+			{ waitUntil: 'domcontentloaded' }
+		);
+
+		await locator.getContinueToSetupButton().click();
+
+		await page.waitForURL(
+			'**/wp-admin/admin.php?page=wc-admin&path=%2Fsnapchat%2Fsettings&onboarding=success'
+		);
+		expect( await page.url() ).toContain(
+			'/wp-admin/admin.php?page=wc-admin&path=%2Fsnapchat%2Fsettings&onboarding=success'
+		);
+
+		await expect( locator.getOnboardingSuccessfulModal() ).toBeVisible();
+
+		await locator.getOnboardingSuccessfulCloseModalButton().first().click();
+		await expect(
+			locator.getOnboardingSuccessfulModal()
+		).not.toBeVisible();
+		await page.waitForURL(
+			'**/wp-admin/admin.php?page=wc-admin&path=%2Fsnapchat%2Fsettings'
+		);
+		expect( await page.url() ).toContain(
+			'/wp-admin/admin.php?page=wc-admin&path=%2Fsnapchat%2Fsettings'
+		);
+	} );
+
 	test( 'Shows all sections', async () => {
 		settingPage.goto();
 

--- a/tests/e2e/utils/element-locators.js
+++ b/tests/e2e/utils/element-locators.js
@@ -73,6 +73,37 @@ export default class ElementLocators {
 	}
 
 	/**
+	 * Get the continue button that navigates to the setup screen after click.
+	 *
+	 * @return {import('@playwright/test').Locator} The continue button locator.
+	 */
+	getContinueToSetupButton() {
+		return this.page.getByRole( 'button', { name: 'Continue' } );
+	}
+
+	/**
+	 * Get the modal shown after successful onboarding.
+	 *
+	 * @return {import('@playwright/test').Locator} The onboarding successful modal.
+	 */
+	getOnboardingSuccessfulModal() {
+		return this.page.locator( '.sfw-onboarding-success-modal', {
+			hasText: 'You’ve successfully set up Snapchat for WooCommerce! 🎉',
+		} );
+	}
+
+	/**
+	 * Get the modal shown after successful onboarding.
+	 *
+	 * @return {import('@playwright/test').Locator} The onboarding successful modal.
+	 */
+	getOnboardingSuccessfulCloseModalButton() {
+		return this.getOnboardingSuccessfulModal().getByRole( 'button', {
+			name: 'Close',
+		} );
+	}
+
+	/**
 	 * Get the disconnect button inside the Snapchat account card.
 	 *
 	 * @return {import('@playwright/test').Locator} The disconnect button locator.


### PR DESCRIPTION
- Related to https://linear.app/a8c/issue/SNAPWOO-26/the-success-modal-doesnt-show-when-completing-the-onboarding
- Branched off PR #17 
