### PR TITLE
Fix QA issues.

### DIFF
--- a/js/src/components/section/index.scss
+++ b/js/src/components/section/index.scss
@@ -14,6 +14,8 @@
 	}
 
 	&__header {
+		padding-bottom: wpVariables.$grid-unit-10;
+
 		@include wpMixins.break-small {
 			width: 33%;
 			padding-top: var(--main-gap);

--- a/js/src/hooks/useAdminUrl.js
+++ b/js/src/hooks/useAdminUrl.js
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+import { getSetting } from '@woocommerce/settings'; // eslint-disable-line import/no-unresolved
+// The above is an unpublished package, delivered with WC, we use Dependency Extraction Webpack Plugin to import it.
+// See https://github.com/woocommerce/woocommerce-admin/issues/7781
+
+/**
+ * Get the base URL of WP admin. For example: 'https://example.com/wp-admin/'
+ *
+ * @return {string} The base URL of WP admin.
+ */
+const useAdminUrl = () => getSetting( 'adminUrl' );
+
+export default useAdminUrl;

--- a/js/src/hooks/useMenuEffect.js
+++ b/js/src/hooks/useMenuEffect.js
@@ -8,8 +8,8 @@ import { useEffect } from '@wordpress/element';
  *
  * @see https://github.com/woocommerce/woocommerce-admin/blob/release/2.7.1/client/layout/controller.js#L240-L244
  */
-const dashboardPage = {
-	match: { url: '/snapchat/dashboard' },
+const startPage = {
+	match: { url: '/snapchat/start' },
 	wpOpenMenu: 'toplevel_page_woocommerce-marketing',
 };
 
@@ -25,6 +25,6 @@ const dashboardPage = {
  */
 export default function useMenuEffect() {
 	return useEffect( () => {
-		window.wpNavMenuClassChange( dashboardPage, dashboardPage.match.url );
+		window.wpNavMenuClassChange( startPage, startPage.match.url );
 	} );
 }

--- a/js/src/pages/onboarding/setup-top-bar.js
+++ b/js/src/pages/onboarding/setup-top-bar.js
@@ -2,20 +2,22 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { getNewPath } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
  */
+import useAdminUrl from '~/hooks/useAdminUrl';
 import TopBar from '~/components/stepper/top-bar';
 import HelpIconButton from '~/components/help-icon-button';
 
 const SetupTopBar = () => {
+	const adminUrl = useAdminUrl();
+
 	return (
 		<TopBar
 			title={ __( 'Get started with Snapchat', 'snapchat-for-woo' ) }
 			helpButton={ <HelpIconButton eventContext="setup-snapchat" /> }
-			backHref={ getNewPath( {}, '/snapchat/start' ) }
+			backHref={ adminUrl }
 		/>
 	);
 };

--- a/js/src/pages/settings/index.scss
+++ b/js/src/pages/settings/index.scss
@@ -11,7 +11,6 @@
 		header {
 			max-width: 328px;
 			padding-top: var(--large-gap);
-			padding-bottom: wpVariables.$grid-unit-10;
 		}
 	}
 


### PR DESCRIPTION
Closes 

- https://linear.app/a8c/issue/SNAPWOO-30/back-button-doesnt-respond-on-accounts-connection-screen
- https://linear.app/a8c/issue/SNAPWOO-28/mobile-issues-there-is-less-margin-between-the-card-and-the-header
- https://linear.app/a8c/issue/SNAPWOO-29/snapchat-tab-should-be-active-when-plugin-related-screens-are-open