### PR TITLE
fix/SNAPWOO-41: Implement auto Catalog and Feed generation

### DIFF
--- a/includes/API/AdPartner/AdPartnerApi.php
+++ b/includes/API/AdPartner/AdPartnerApi.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Entry point for interacting with the Ad Partner's catalog and feed APIs.
+ *
+ * This class acts as a centralized service layer for managing all API-related
+ * operations required to interface with the Ad Partner's systems via WooCommerce Connect Server (WCS).
+ * It encapsulates submodules like {@see CatalogApi} and {@see FeedApi}, and ensures that only
+ * a single instance of this class is instantiated during the request lifecycle.
+ *
+ * This wrapper ensures a clean and testable separation between API logic and
+ * higher-level business workflows, facilitating future extension with additional
+ * API modules.
+ *
+ * @package SnapchatForWooCommerce\API\AdPartner
+ */
+
+namespace SnapchatForWooCommerce\API\AdPartner;
+
+use SnapchatForWooCommerce\Connection\WcsClient;
+
+/**
+ * Central service class for Ad Partner API interactions.
+ *
+ * Designed as a singleton to ensure a consistent WCS client instance is shared
+ * across all subcomponents.
+ *
+ * @since 0.1.0
+ */
+class AdPartnerApi {
+	/**
+	 * Singleton instance of the API service.
+	 *
+	 * Ensures only one instance of this class exists per request lifecycle.
+	 *
+	 * @since 0.1.0
+	 * @var self|null
+	 */
+	private static ?self $instance = null;
+
+	/**
+	 * Handles product catalog operations.
+	 *
+	 * @since 0.1.0
+	 * @var CatalogApi
+	 */
+	public CatalogApi $catalog;
+
+	/**
+	 * Handles product feed operations.
+	 *
+	 * @since 0.1.0
+	 * @var FeedApi
+	 */
+	public FeedApi $feed;
+
+	/**
+	 * Private constructor to enforce singleton pattern.
+	 *
+	 * Initializes all API submodules with the shared {@see WcsClient} instance,
+	 * ensuring consistent communication with WooCommerce Connect Server.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param WcsClient $wcs WCS client used for authenticated proxy API requests.
+	 */
+	private function __construct( WcsClient $wcs ) {
+		$this->catalog = new CatalogApi( $wcs );
+		$this->feed    = new FeedApi( $wcs );
+	}
+
+	/**
+	 * Returns the singleton instance of the API service.
+	 *
+	 * Creates a new instance on the first call and reuses it for subsequent requests.
+	 * Ensures that all API modules use the same underlying {@see WcsClient}.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param WcsClient $wcs WCS client used for authenticated proxy API requests.
+	 * @return self Singleton instance of this class.
+	 */
+	public static function get_instance( WcsClient $wcs ): self {
+		if ( null === self::$instance ) {
+			self::$instance = new self( $wcs );
+		}
+
+		return self::$instance;
+	}
+}

--- a/includes/API/AdPartner/BaseAdPartnerApi.php
+++ b/includes/API/AdPartner/BaseAdPartnerApi.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Abstract base class for Ad Partner API modules.
+ *
+ * Provides a common foundation for all API module classes that interact with
+ * the Ad Partner through WooCommerce Connect Server (WCS). This class stores
+ * a reference to the shared {@see WcsClient} instance used for authenticated
+ * HTTP requests to the WCS proxy endpoints.
+ *
+ * All specific API modules (e.g., CatalogApi, FeedApi) should extend this class
+ * to gain access to the WCS client and promote consistent request handling.
+ *
+ * @package SnapchatForWooCommerce\API\AdPartner
+ */
+
+namespace SnapchatForWooCommerce\Api\AdPartner;
+
+use SnapchatForWooCommerce\Connection\WcsClient;
+
+/**
+ * Base class for API modules that communicate with the Ad Partner via WCS.
+ *
+ * Encapsulates the shared WCS client and provides foundational setup
+ * for subclasses handling specific API concerns (catalogs, feeds, etc).
+ *
+ * @since 0.1.0
+ */
+class BaseAdPartnerApi {
+	/**
+	 * WCS client used to proxy API requests to the Ad Partner.
+	 *
+	 * This instance provides authentication and routing logic for sending
+	 * HTTP requests to the correct WooCommerce Connect Server endpoint.
+	 *
+	 * @since 0.1.0
+	 * @var WcsClient
+	 */
+	protected WcsClient $wcs;
+
+	/**
+	 * Constructor.
+	 *
+	 * Accepts a {@see WcsClient} instance used for all outgoing API calls
+	 * made by this module or its subclasses.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param WcsClient $wcs WCS client instance.
+	 */
+	public function __construct( WcsClient $wcs ) {
+		$this->wcs = $wcs;
+	}
+}

--- a/includes/API/AdPartner/CatalogApi.php
+++ b/includes/API/AdPartner/CatalogApi.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * API module for managing product catalogs.
+ *
+ * This class provides an interface for interacting with the Ad Partner's
+ * Catalog API via WooCommerce Connect Server (WCS). It supports catalog-related
+ * operations such as creation, and can be extended to include retrieval,
+ * deletion, or updates in the future.
+ *
+ * Requests are constructed using merchant-specific identifiers and sent to
+ * the WCS proxy endpoint, which handles secure authentication and communication
+ * with the Ad Partner's remote API.
+ *
+ * @since 0.1.0
+ * @package SnapchatForWooCommerce\API\AdPartner
+ */
+
+namespace SnapchatForWooCommerce\API\AdPartner;
+
+use SnapchatForWooCommerce\Api\AdPartner\BaseAdPartnerApi;
+use SnapchatForWooCommerce\Utils\Storage\Options;
+use SnapchatForWooCommerce\Utils\Storage\OptionDefaults;
+use SnapchatForWooCommerce\Utils\Helper;
+use WP_Error;
+
+/**
+ * API module for managing product catalogs.
+ *
+ * This class provides the ability to create a new catalog under the merchant's
+ * Ad Partner account, associating it with an existing Pixel.
+ *
+ * @since 0.1.0
+ */
+class CatalogApi extends BaseAdPartnerApi {
+
+	/**
+	 * Creates a product catalog for the current merchant organization.
+	 *
+	 * This method builds and submits the catalog creation request using the
+	 * organization ID and Pixel ID configured in the plugin settings.
+	 *
+	 * It returns a {@see WP_REST_Response} on success or a {@see WP_Error}
+	 * on failure, depending on whether the required prerequisites are met.
+	 *
+	 * Requirements:
+	 * - Organization ID must be saved in plugin options.
+	 * - Pixel ID must be saved in plugin options.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @return \WP_REST_Response|WP_Error REST response from WCS or error if inputs are missing.
+	 */
+	public function create() {
+		$org_id = Options::get( OptionDefaults::ORGANIZATION_ID );
+
+		if ( ! $org_id ) {
+			return new WP_Error(
+				'org_id_not_set',
+				__( 'Organization ID not found.', 'snapchat-for-woocommerce' ),
+			);
+		}
+
+		$pixel_id = Options::get( OptionDefaults::PIXEL_ID );
+
+		if ( ! $pixel_id ) {
+			return new WP_Error(
+				'pixel_id_not_set',
+				__( 'Pixel ID not found.', 'snapchat-for-woocommerce' ),
+			);
+		}
+
+		$payload = array(
+			'catalogs' => array(
+				array(
+					'organization_id' => $org_id,
+					'name'            => Helper::get_store_name( 'catalog' ),
+					'vertical'        => 'COMMERCE',
+					'event_sources'   => array(
+						array(
+							'id'   => $pixel_id,
+							'type' => 'PIXEL',
+						),
+					),
+				),
+			),
+		);
+
+		$response = $this->wcs->proxy_post(
+			'/ads/v1/organizations/' . $org_id . '/catalogs',
+			$payload
+		);
+
+		return $response;
+	}
+}

--- a/includes/API/AdPartner/CatalogApi.php
+++ b/includes/API/AdPartner/CatalogApi.php
@@ -17,7 +17,7 @@
 
 namespace SnapchatForWooCommerce\API\AdPartner;
 
-use SnapchatForWooCommerce\Api\AdPartner\BaseAdPartnerApi;
+use SnapchatForWooCommerce\API\AdPartner\BaseAdPartnerApi;
 use SnapchatForWooCommerce\Utils\Storage\Options;
 use SnapchatForWooCommerce\Utils\Storage\OptionDefaults;
 use SnapchatForWooCommerce\Utils\Helper;

--- a/includes/API/AdPartner/FeedApi.php
+++ b/includes/API/AdPartner/FeedApi.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * API module for managing product feeds.
+ *
+ * This class provides an interface for interacting with the Ad Partner's
+ * Feed API via WooCommerce Connect Server (WCS). It supports feed-related
+ * operations such as creation, and can be extended to include retrieval,
+ * deletion, or updates in the future.
+ *
+ * Requests are constructed using merchant-specific identifiers and sent to
+ * the WCS proxy endpoint, which handles secure authentication and communication
+ * with the Ad Partner's remote API.
+ *
+ * @since 0.1.0
+ * @package SnapchatForWooCommerce\API\AdPartner
+ */
+
+namespace SnapchatForWooCommerce\API\AdPartner;
+
+use SnapchatForWooCommerce\Api\AdPartner\BaseAdPartnerApi;
+use SnapchatForWooCommerce\Utils\Storage\Options;
+use SnapchatForWooCommerce\Utils\Storage\OptionDefaults;
+use SnapchatForWooCommerce\Utils\Helper;
+use WP_Error;
+
+/**
+ * API module for managing product feeds.
+ *
+ * This class provides the ability to create a new product feed within an
+ * existing catalog under the merchant's Ad Partner account.
+ *
+ * @since 0.1.0
+ */
+class FeedApi extends BaseAdPartnerApi {
+
+	/**
+	 * Creates a product feed for the current catalog.
+	 *
+	 * This method submits the feed creation request using the
+	 * catalog ID configured in the plugin options.
+	 *
+	 * It returns a {@see WP_REST_Response} on success or a {@see WP_Error}
+	 * on failure, depending on whether the required prerequisites are met.
+	 *
+	 * Requirements:
+	 * - Catalog ID must be saved in plugin options.
+	 * - Feed URL must be available via {@see OptionDefaults::EXPORT_FILE_URL}.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @return \WP_REST_Response|WP_Error REST response from WCS or error if inputs are missing.
+	 */
+	public function create() {
+		$catalog_id = Options::get( OptionDefaults::CATALOG_ID );
+
+		if ( ! $catalog_id ) {
+			return new WP_Error(
+				'catalog_id_not_set',
+				__( 'Catalog ID not found.', 'snapchat-for-woocommerce' ),
+			);
+		}
+
+		$payload = array(
+			'product_feeds' => array(
+				array(
+					'catalog_id'       => $catalog_id,
+					'name'             => Helper::get_store_name( 'feed' ),
+					'default_currency' => get_woocommerce_currency(),
+					'status'           => 'ACTIVE',
+					'vertical'         => 'COMMERCE',
+					'schedule'         => array(
+						'interval_type' => 'DAILY',
+						'timezone'      => get_option( 'timezone_string' ),
+						'url'           => Options::get( OptionDefaults::EXPORT_FILE_URL ),
+					),
+				),
+			),
+		);
+
+		$response = $this->wcs->proxy_post(
+			'/ads/v1/catalogs/' . $catalog_id . '/product_feeds',
+			$payload
+		);
+
+		return $response;
+	}
+}

--- a/includes/API/AdPartner/FeedApi.php
+++ b/includes/API/AdPartner/FeedApi.php
@@ -17,7 +17,7 @@
 
 namespace SnapchatForWooCommerce\API\AdPartner;
 
-use SnapchatForWooCommerce\Api\AdPartner\BaseAdPartnerApi;
+use SnapchatForWooCommerce\API\AdPartner\BaseAdPartnerApi;
 use SnapchatForWooCommerce\Utils\Storage\Options;
 use SnapchatForWooCommerce\Utils\Storage\OptionDefaults;
 use SnapchatForWooCommerce\Utils\Helper;

--- a/includes/API/AdPartner/FeedApi.php
+++ b/includes/API/AdPartner/FeedApi.php
@@ -21,6 +21,7 @@ use SnapchatForWooCommerce\Api\AdPartner\BaseAdPartnerApi;
 use SnapchatForWooCommerce\Utils\Storage\Options;
 use SnapchatForWooCommerce\Utils\Storage\OptionDefaults;
 use SnapchatForWooCommerce\Utils\Helper;
+use SnapchatForWooCommerce\Admin\Export\Writer\CsvExportWriter;
 use WP_Error;
 
 /**
@@ -71,7 +72,12 @@ class FeedApi extends BaseAdPartnerApi {
 					'schedule'         => array(
 						'interval_type' => 'DAILY',
 						'timezone'      => get_option( 'timezone_string' ),
-						'url'           => Options::get( OptionDefaults::EXPORT_FILE_URL ),
+						'url'           => sprintf(
+							'%1$s/%2$s/products-%3$s.csv',
+							$this->wcs->get_wcs_url(),
+							CsvExportWriter::EXPORT_FOLDER,
+							Options::get( OptionDefaults::WCS_PRODUCTS_TOKEN )
+						),
 					),
 				),
 			),

--- a/includes/API/SetupService.php
+++ b/includes/API/SetupService.php
@@ -17,6 +17,7 @@ use SnapchatForWooCommerce\ServiceContainer;
 use SnapchatForWooCommerce\ServiceKey;
 use SnapchatForWooCommerce\Config;
 use SnapchatForWooCommerce\API\Site\Controllers;
+use SnapchatForWooCommerce\API\AdPartner\AdPartnerApi;
 
 /**
  * Bootstrap class for registering REST API routes related to plugin settings.
@@ -42,11 +43,12 @@ class SetupService {
 	 * @return void
 	 */
 	public function register_routes(): void {
-		$wcs_client = ServiceContainer::get( ServiceKey::WCS_CLIENT );
-		$manager    = new Manager( Config::PLUGIN_SLUG );
+		$wcs_client     = ServiceContainer::get( ServiceKey::WCS_CLIENT );
+		$manager        = new Manager( Config::PLUGIN_SLUG );
+		$ad_partner_api = AdPartnerApi::get_instance( $wcs_client );
 
 		( new Controllers\JetpackAccountController( $wcs_client, $manager ) )->register_routes();
-		( new Controllers\SnapchatBusinessExtensionController( $wcs_client ) )->register_routes();
+		( new Controllers\SnapchatBusinessExtensionController( $wcs_client, $ad_partner_api ) )->register_routes();
 		( new Controllers\SnapchatAccountController() )->register_routes();
 		( new Controllers\OnboardingController() )->register_routes();
 		( new Controllers\SettingsController() )->register_routes();

--- a/includes/API/Site/Controllers/SnapchatAccountController.php
+++ b/includes/API/Site/Controllers/SnapchatAccountController.php
@@ -16,7 +16,6 @@ namespace SnapchatForWooCommerce\API\Site\Controllers;
 
 use WP_REST_Response;
 use SnapchatForWooCommerce\Config;
-use SnapchatForWooCommerce\Connection\WcsClient;
 use SnapchatForWooCommerce\Utils\Storage\Options;
 use SnapchatForWooCommerce\Utils\Storage\OptionDefaults;
 

--- a/includes/API/Site/Controllers/SnapchatBusinessExtensionController.php
+++ b/includes/API/Site/Controllers/SnapchatBusinessExtensionController.php
@@ -98,8 +98,13 @@ class SnapchatBusinessExtensionController extends RESTBaseController {
 					'callback'            => array( $this, 'set_config' ),
 					'permission_callback' => array( $this, 'permissions_check' ),
 					'args'                => array(
-						'id' => array(
+						'id'             => array(
 							'description' => 'The config_id returned by Snapchat.',
+							'type'        => 'string',
+							'required'    => true,
+						),
+						'products_token' => array(
+							'description' => 'The products_token returned by WCS.',
 							'type'        => 'string',
 							'required'    => true,
 						),
@@ -158,13 +163,23 @@ class SnapchatBusinessExtensionController extends RESTBaseController {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function set_config( $request ) {
-		$config_id = sanitize_text_field( $request['id'] );
+		$config_id      = sanitize_text_field( $request['id'] );
+		$products_token = sanitize_text_field( $request['products_token'] );
 
 		if ( empty( $config_id ) ) {
 			return rest_ensure_response( ( array( 'id' => '' ) ) );
 		}
 
 		Options::set( OptionDefaults::CONFIG_ID, $config_id );
+
+		if ( empty( $products_token ) ) {
+			$logger = wc_get_logger();
+			$logger->warning(
+				'products_token not set. Auto product feed creation will fail.'
+			);
+		} else {
+			Options::set( OptionDefaults::WCS_PRODUCTS_TOKEN, $products_token );
+		}
 
 		$response = $this->wcs->proxy_get( '/ads/v1/business_extension_configurations/' . $config_id );
 

--- a/includes/API/Site/Controllers/SnapchatBusinessExtensionController.php
+++ b/includes/API/Site/Controllers/SnapchatBusinessExtensionController.php
@@ -24,6 +24,7 @@ use SnapchatForWooCommerce\Utils\Storage\OptionDefaults;
 use SnapchatForWooCommerce\Utils\Storage\Transients;
 use SnapchatForWooCommerce\Utils\Storage\TransientDefaults;
 use SnapchatForWooCommerce\Utils\Helper;
+use SnapchatForWooCommerce\API\AdPartner\AdPartnerApi;
 
 /**
  * Controller for setting up and managing the Snapchat account connection.
@@ -40,12 +41,21 @@ class SnapchatBusinessExtensionController extends RESTBaseController {
 	protected WcsClient $wcs;
 
 	/**
+	 * Instance of the Ad Partner API.
+	 *
+	 * @var AdPartnerApi
+	 */
+	protected AdPartnerApi $ad_partner_api;
+
+	/**
 	 * Constructor.
 	 *
-	 * @param WcsClient $wcs WCS proxy request client.
+	 * @param WcsClient    $wcs            WCS proxy request client.
+	 * @param AdPartnerApi $ad_partner_api Ad Partner API.
 	 */
-	public function __construct( WcsClient $wcs ) {
-		$this->wcs = $wcs;
+	public function __construct( WcsClient $wcs, AdPartnerApi $ad_partner_api ) {
+		$this->wcs            = $wcs;
+		$this->ad_partner_api = $ad_partner_api;
 	}
 
 	/**
@@ -197,6 +207,27 @@ class SnapchatBusinessExtensionController extends RESTBaseController {
 
 		Options::set( OptionDefaults::ONBOARDING_STATUS, 'connected' );
 
+		$response = $this->ad_partner_api->catalog->create();
+
+		if ( is_wp_error( $response ) ) {
+			return new WP_REST_Response(
+				array(
+					'status'  => 'error',
+					'message' => $response->get_error_message(),
+				),
+				500
+			);
+		}
+
+		$data         = $response->get_data();
+		$catalog_data = $data['catalogs'];
+
+		if ( ! empty( $catalog_data ) && ! empty( $catalog_data[0] ) ) {
+			$catalog = $catalog_data[0]['catalog'];
+
+			Options::set( OptionDefaults::CATALOG_ID, $catalog['id'] );
+		}
+
 		/**
 		 * Triggers when the Snapchat onboarding process is completed.
 		 *
@@ -211,6 +242,7 @@ class SnapchatBusinessExtensionController extends RESTBaseController {
 				'ad_acc_id'   => Options::get( OptionDefaults::AD_ACCOUNT_ID ),
 				'ad_acc_name' => Options::get( OptionDefaults::AD_ACCOUNT_NAME ),
 				'pixel_id'    => Options::get( OptionDefaults::PIXEL_ID ),
+				'catalog_id'  => Options::get( OptionDefaults::CATALOG_ID ),
 			)
 		);
 	}
@@ -415,6 +447,10 @@ class SnapchatBusinessExtensionController extends RESTBaseController {
 				),
 				'pixel_id'    => array(
 					'description' => 'Selected Pixel id.',
+					'type'        => 'string',
+				),
+				'catalog_id'  => array(
+					'description' => 'Created Catalog id.',
 					'type'        => 'string',
 				),
 			),

--- a/includes/Admin/Export/BatchExportJob.php
+++ b/includes/Admin/Export/BatchExportJob.php
@@ -101,7 +101,7 @@ class BatchExportJob {
 		ExportableEntityProviderInterface $provider,
 		ExportRowBuilderInterface $row_builder,
 		ExportWriterInterface $writer,
-		AdPartnerApi $ad_partner_api,
+		AdPartnerApi $ad_partner_api
 	) {
 		$this->cache_builder  = $cache_builder;
 		$this->provider       = $provider;

--- a/includes/Admin/Export/BatchExportJob.php
+++ b/includes/Admin/Export/BatchExportJob.php
@@ -24,6 +24,8 @@ use SnapchatForWooCommerce\Admin\Export\Contract\CacheBuilderInterface;
 use SnapchatForWooCommerce\Utils\Helper;
 use SnapchatForWooCommerce\Utils\Storage\Options;
 use SnapchatForWooCommerce\Utils\Storage\OptionDefaults;
+use SnapchatForWooCommerce\API\AdPartner\AdPartnerApi;
+use WC_Logger_Interface;
 
 /**
  * Executes a single export batch for any entity type.
@@ -77,25 +79,35 @@ class BatchExportJob {
 	public ExportWriterInterface $writer;
 
 	/**
+	 * Provides access to the Ad Partner APIs.
+	 *
+	 * @var AdPartnerApi
+	 */
+	public AdPartnerApi $ad_partner_api;
+
+	/**
 	 * Constructor.
 	 *
 	 * @since 0.1.0
 	 *
-	 * @param CacheBuilderInterface             $cache_builder Prepares and caches exportable entity IDs ahead of export.
-	 * @param ExportableEntityProviderInterface $provider      Supplies exportable entity IDs and objects.
-	 * @param ExportRowBuilderInterface         $row_builder   Builds CSV-compatible row data from entities.
-	 * @param ExportWriterInterface             $writer        Writes data to file and manages file output.
+	 * @param CacheBuilderInterface             $cache_builder  Prepares and caches exportable entity IDs ahead of export.
+	 * @param ExportableEntityProviderInterface $provider       Supplies exportable entity IDs and objects.
+	 * @param ExportRowBuilderInterface         $row_builder    Builds CSV-compatible row data from entities.
+	 * @param ExportWriterInterface             $writer         Writes data to file and manages file output.
+	 * @param AdPartnerApi                      $ad_partner_api Exposes Ad Partner APIs.
 	 */
 	public function __construct(
 		CacheBuilderInterface $cache_builder,
 		ExportableEntityProviderInterface $provider,
 		ExportRowBuilderInterface $row_builder,
-		ExportWriterInterface $writer
+		ExportWriterInterface $writer,
+		AdPartnerApi $ad_partner_api,
 	) {
-		$this->cache_builder = $cache_builder;
-		$this->provider      = $provider;
-		$this->row_builder   = $row_builder;
-		$this->writer        = $writer;
+		$this->cache_builder  = $cache_builder;
+		$this->provider       = $provider;
+		$this->row_builder    = $row_builder;
+		$this->writer         = $writer;
+		$this->ad_partner_api = $ad_partner_api;
 	}
 
 	/**
@@ -194,5 +206,35 @@ class BatchExportJob {
 	 */
 	public function set_timestamp(): void {
 		Options::set( OptionDefaults::LAST_EXPORT_TIMESTAMP, time() );
+	}
+
+	/**
+	 * Finalizes the export batch and triggers post-export actions.
+	 *
+	 * This method is called when a batch export process has completed. It performs
+	 * post-export tasks.
+	 *
+	 * This is typically invoked by the export orchestration layer after all entities
+	 * in the batch have been successfully exported.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param callable $callback A user-defined function or method to be executed after export completion.
+	 * @return void
+	 */
+	public function on_complete( callable $callback ): void {
+		if ( is_callable( $callback ) ) {
+			$callback();
+		}
+
+		/**
+		 * Fires when a batch export job has been completed.
+		 *
+		 * This hook indicates that all export tasks in the current batch have finished processing.
+		 * It can be used to trigger post-export actions, such as cleanup, notification, or further data processing.
+		 *
+		 * @since 0.1.0
+		 */
+		do_action( Helper::with_prefix( 'batch_export_job_complete' ) );
 	}
 }

--- a/includes/Admin/Export/Service/ProductExportService.php
+++ b/includes/Admin/Export/Service/ProductExportService.php
@@ -115,6 +115,11 @@ class ProductExportService {
 			array( $this, 'check_export_status' ),
 			10
 		);
+
+		add_action(
+			Helper::with_prefix( 'batch_export_job_complete' ),
+			array( $this, 'create_feed' )
+		);
 	}
 
 	/**
@@ -285,15 +290,20 @@ class ProductExportService {
 	public function handle_batch( int $offset = 0, ?string $existing_file = null ): void {
 		$is_first_batch = ( 0 === $offset );
 
-		$result = $this->job->run( $offset, $is_first_batch, $existing_file );
-
-		if ( $is_first_batch ) {
+		$result      = $this->job->run( $offset, $is_first_batch, $existing_file );
+		$is_complete = $result['complete'];
+		$on_complete = function () use ( $result ) {
 			Options::set( OptionDefaults::EXPORT_FILE_PATH, $result['file_path'] );
 			Options::set( OptionDefaults::EXPORT_FILE_URL, $result['file_url'] );
 			$this->job->set_timestamp();
+		};
+
+		if ( $is_first_batch && $is_complete ) {
+			$this->job->on_complete( $on_complete );
+			return;
 		}
 
-		if ( ! $result['complete'] ) {
+		if ( ! $is_complete ) {
 			as_enqueue_async_action(
 				Helper::with_prefix( self::ACTION_HOOK ),
 				array(
@@ -303,7 +313,7 @@ class ProductExportService {
 				Config::PLUGIN_SLUG
 			);
 		} else {
-			$this->job->set_timestamp();
+			$this->job->on_complete( $on_complete );
 		}
 	}
 
@@ -363,5 +373,33 @@ class ProductExportService {
 		);
 
 		wp_send_json( $response );
+	}
+
+	/**
+	 * Invokes the Ad Partner API to create a product feed after export completes.
+	 *
+	 * This method is hooked to {@see Helper::with_prefix( 'batch_export_job_complete' )}.
+	 * It is triggered automatically after the final export batch has finished and the
+	 * CSV feed file has been successfully written.
+	 *
+	 * - Calls {@see FeedApi::create()} to register the feed with the Ad Partner.
+	 * - Logs an alert if feed creation fails with a WP_Error.
+	 *
+	 * This final step ensures that the exported product catalog is registered
+	 * as a feed with the Ad Partner for ingestion and use in Dynamic Ads.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @return void
+	 */
+	public function create_feed() {
+		$response = $this->job->ad_partner_api->feed->create();
+
+		if ( is_wp_error( $response ) ) {
+			$logger = wc_get_logger();
+			$logger->alert(
+				'Feed generation failed with error code' . $response->get_error_code(),
+			);
+		}
 	}
 }

--- a/includes/Admin/Export/Writer/CsvExportWriter.php
+++ b/includes/Admin/Export/Writer/CsvExportWriter.php
@@ -12,6 +12,8 @@
 namespace SnapchatForWooCommerce\Admin\Export\Writer;
 
 use SnapchatForWooCommerce\Admin\Export\Contract\ExportWriterInterface;
+use SnapchatForWooCommerce\Utils\Storage\Options;
+use SnapchatForWooCommerce\Utils\Storage\OptionDefaults;
 use WP_Filesystem_Direct;
 
 /**
@@ -30,7 +32,7 @@ class CsvExportWriter implements ExportWriterInterface {
 	 *
 	 * @since 0.1.0
 	 */
-	const EXPORT_FOLDER = 'snapchat-exports';
+	const EXPORT_FOLDER = 'snapchat';
 
 	/**
 	 * Filesystem handler.
@@ -84,7 +86,7 @@ class CsvExportWriter implements ExportWriterInterface {
 			}
 		}
 
-		$filename = 'catalog-export-' . gmdate( 'Ymd-His' ) . '.csv';
+		$filename = 'products-' . Options::get( OptionDefaults::WCS_PRODUCTS_TOKEN ) . '.csv';
 		$file     = trailingslashit( $dir_path ) . $filename;
 
 		$success = $this->fs->put_contents( $file, '' );

--- a/includes/Connection/WcsClient.php
+++ b/includes/Connection/WcsClient.php
@@ -100,7 +100,7 @@ final class WcsClient {
 	 *
 	 * @return string
 	 */
-	private function get_wcs_url(): string {
+	public function get_wcs_url(): string {
 		/**
 		 * Filters the base URL for the WCS (Web Conversion Service) endpoint.
 		 *

--- a/includes/ServiceContainer.php
+++ b/includes/ServiceContainer.php
@@ -20,7 +20,9 @@ use SnapchatForWooCommerce\Admin;
 use SnapchatForWooCommerce\Admin\Export;
 use SnapchatForWooCommerce\Admin\ProductMeta;
 use SnapchatForWooCommerce\Tracking\ConversionEventLogger;
-use WC_Logger;
+use SnapchatForWooCommerce\API\AdPartner\AdPartnerApi;
+use function wc_get_logger;
+
 
 /**
  * Static service container for resolving shared instances across the Ad Partner plugin.
@@ -103,6 +105,9 @@ final class ServiceContainer {
 						new Export\EntityProvider\ProductEntityProvider(),
 						new Export\RowBuilder\ProductRowBuilder(),
 						new Export\Writer\CsvExportWriter(),
+						AdPartnerApi::get_instance(
+							self::get( ServiceKey::WCS_CLIENT )
+						),
 					)
 				);
 			case ServiceKey::ADMIN_SETUP:

--- a/includes/Utils/Helper.php
+++ b/includes/Utils/Helper.php
@@ -120,4 +120,26 @@ class Helper {
 
 		return count( $product ) > 0;
 	}
+
+	/**
+	 * Generates a unique store name based on the site's home URL and the current timestamp.
+	 *
+	 * This function removes the protocol (http:// or https://) from the home URL
+	 * and appends the current Unix timestamp to ensure uniqueness.
+	 *
+	 * @param string $suffix Suffix to be appended to the store name.
+	 *
+	 * @return string A string composed of the cleaned home URL and the current timestamp.
+	 */
+	public static function get_store_name( string $suffix = '' ): string {
+		$home_url   = get_home_url();
+		$clean_url  = preg_replace( '#^https?://#', '', $home_url );
+		$store_name = $clean_url . '_woocommerce_' . time();
+
+		if ( $suffix ) {
+			$store_name .= '_' . $suffix;
+		}
+
+		return $store_name;
+	}
 }

--- a/includes/Utils/Storage/OptionDefaults.php
+++ b/includes/Utils/Storage/OptionDefaults.php
@@ -179,6 +179,14 @@ final class OptionDefaults {
 	public const LAST_EXPORT_TIMESTAMP = 'last_export_timestamp';
 
 	/**
+	 * Option key to store the WCS token to create file name for
+	 * generating catalog CSV filename.
+	 *
+	 * @since 0.1.0
+	 */
+	public const WCS_PRODUCTS_TOKEN = 'wcs_products_token';
+
+	/**
 	 * Returns default values for all known Ad Partner options.
 	 *
 	 * Used by {@see Options} to provide fallbacks when option values
@@ -209,6 +217,7 @@ final class OptionDefaults {
 			self::EXPORT_FILE_URL         => '',
 			self::EXPORT_PRODUCT_IDS      => array(),
 			self::LAST_EXPORT_TIMESTAMP   => 0,
+			self::WCS_PRODUCTS_TOKEN      => '',
 		);
 	}
 }

--- a/includes/Utils/Storage/OptionDefaults.php
+++ b/includes/Utils/Storage/OptionDefaults.php
@@ -128,6 +128,20 @@ final class OptionDefaults {
 	public const CONVERSION_ACCESS_TOKEN = 'conversion_access_token';
 
 	/**
+	 * Option key for the Ad Partner's Catalog ID.
+	 *
+	 * @since 0.1.0
+	 */
+	public const CATALOG_ID = 'catalog_id';
+
+	/**
+	 * Option key for the Ad Partner's Product Feed ID.
+	 *
+	 * @since 0.1.0
+	 */
+	public const PRODUCT_FEED_ID = 'product_feed_id';
+
+	/**
 	 * Option key to store the full file system path of the most recent export file.
 	 *
 	 * This value is written during the first export batch and reused across
@@ -189,6 +203,8 @@ final class OptionDefaults {
 			self::PIXEL_ID                => '',
 			self::CONVERSIONS_ENABLED     => 'no',
 			self::CONVERSION_ACCESS_TOKEN => '',
+			self::CATALOG_ID              => '',
+			self::PRODUCT_FEED_ID         => '',
 			self::EXPORT_FILE_PATH        => '',
 			self::EXPORT_FILE_URL         => '',
 			self::EXPORT_PRODUCT_IDS      => array(),

--- a/js/src/components/snapchat-account-card/connect-snapchat-account-card.js
+++ b/js/src/components/snapchat-account-card/connect-snapchat-account-card.js
@@ -26,10 +26,14 @@ import useApiFetchCallback from '~/hooks/useApiFetchCallback';
 /**
  * @fires sfw_snapchat_account_connect_button_click
  */
-const ConnectSnapchatAccountCard = ( { disabled, configId } ) => {
+const ConnectSnapchatAccountCard = ( {
+	disabled,
+	configId,
+	productsToken,
+} ) => {
 	const { createNotice } = useDispatchCoreNotices();
 	const { upsertSnapchatConfig, loading: loadingUpsertSnapchatConfig } =
-		useUpsertSnapchatConfig( configId );
+		useUpsertSnapchatConfig( configId, productsToken );
 	const nextPageName = sfwData?.setupComplete
 		? 'reconnect'
 		: 'setup-snapchat';
@@ -43,7 +47,7 @@ const ConnectSnapchatAccountCard = ( { disabled, configId } ) => {
 		if ( configId ) {
 			upsertSnapchatConfig( configId );
 		}
-	}, [ configId, upsertSnapchatConfig ] );
+	}, [ configId, productsToken, upsertSnapchatConfig ] );
 
 	const handleConnectClick = async () => {
 		try {

--- a/js/src/components/snapchat-account-card/snapchat-account-card.js
+++ b/js/src/components/snapchat-account-card/snapchat-account-card.js
@@ -12,7 +12,7 @@ import ConnectSnapchatAccountCard from './connect-snapchat-account-card';
 
 const SnapchatAccountCard = ( { disabled = false } ) => {
 	const { isConnected } = useSnapchatAccount();
-	const { config_id: configId } = getQuery();
+	const { config_id: configId, products_token: productsToken } = getQuery();
 
 	if ( isConnected ) {
 		return <ConnectedSnapchatAccountCard />;
@@ -22,6 +22,7 @@ const SnapchatAccountCard = ( { disabled = false } ) => {
 		<ConnectSnapchatAccountCard
 			disabled={ disabled }
 			configId={ configId }
+			productsToken={ productsToken }
 		/>
 	);
 };

--- a/js/src/hooks/useUpsertSnapchatConfig.js
+++ b/js/src/hooks/useUpsertSnapchatConfig.js
@@ -27,7 +27,7 @@ import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
  *
  * @see useApiFetchCallback
  */
-const useUpsertSnapchatConfig = ( configId ) => {
+const useUpsertSnapchatConfig = ( configId, productsToken ) => {
 	const { createNotice } = useDispatchCoreNotices();
 	const { fetchSnapchatAccount, fetchSetup } = useAppDispatch();
 	const [ loading, setLoading ] = useState( false );
@@ -37,11 +37,12 @@ const useUpsertSnapchatConfig = ( configId ) => {
 		method: 'POST',
 		data: {
 			id: configId,
+			products_token: productsToken,
 		},
 	} );
 
 	const upsertSnapchatConfig = useCallback( async () => {
-		if ( ! configId ) {
+		if ( ! configId || ! productsToken ) {
 			return false;
 		}
 
@@ -67,6 +68,7 @@ const useUpsertSnapchatConfig = ( configId ) => {
 		fetchSnapchatAccount,
 		fetchSetup,
 		configId,
+		productsToken,
 	] );
 
 	return { upsertSnapchatConfig, loading };

--- a/js/src/pages/settings/product-catalog/index.js
+++ b/js/src/pages/settings/product-catalog/index.js
@@ -3,19 +3,13 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Flex } from '@wordpress/components';
-import {
-	createInterpolateElement,
-	useState,
-	useEffect,
-	useCallback,
-} from '@wordpress/element';
+import { useState, useEffect, useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { sfwData } from '~/constants';
 import AppButton from '~/components/app-button';
-import AppDocumentationLink from '~/components/app-documentation-link';
 import AccountCard from '~/components/account-card';
 import useSettings from '~/hooks/useSettings';
 import useExportPoller from './useExportPoller';

--- a/js/src/pages/settings/product-catalog/index.js
+++ b/js/src/pages/settings/product-catalog/index.js
@@ -130,14 +130,6 @@ const ProductCatalog = () => {
 					>
 						{ __( 'Regenerate CSV', 'snapchat-for-woo' ) }
 					</AppButton>
-					<AppButton
-						variant="primary"
-						href={ fileUrl }
-						disabled={ ! fileUrl }
-						download
-					>
-						{ __( 'Download CSV', 'snapchat-for-woo' ) }
-					</AppButton>
 				</Flex>
 			);
 		}

--- a/js/src/pages/settings/product-catalog/index.js
+++ b/js/src/pages/settings/product-catalog/index.js
@@ -194,33 +194,6 @@ const ProductCatalog = () => {
 						</p>
 					</div>
 				) }
-				{ hasExport && (
-					<div className="sfw-product-catalog__help">
-						<p>
-							{ __(
-								'You can download the latest CSV or regenerate it if you’ve made changes.',
-								'snapchat-for-woo'
-							) }
-						</p>
-						<p>
-							{ createInterpolateElement(
-								__(
-									'Need help? Learn how to <link>upload</link> your CSV to Snapchat.',
-									'snapchat-for-woo'
-								),
-								{
-									link: (
-										<AppDocumentationLink
-											context="settings"
-											linkId="csv-learn-more"
-											href="https://businesshelp.snapchat.com/s/article/manual-add-catalog?language=en_GB"
-										/>
-									),
-								}
-							) }
-						</p>
-					</div>
-				) }
 			</AccountCard>
 		</>
 	);

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
 		"lint": "npm run lint:php && npm run lint:js && npm run lint:css",
 		"lint:css": "wp-scripts lint-style",
 		"lint:js": "wp-scripts lint-js",
+		"lint:js:fix": "wp-scripts lint-js --fix",
 		"lint:php": "vendor/bin/phpcs",
 		"packages-update": "wp-scripts packages-update",
 		"plugin-zip": "wp-scripts plugin-zip",

--- a/tests/Unit/API/Controllers/SnapchatBusinessExtensionControllerTest.php
+++ b/tests/Unit/API/Controllers/SnapchatBusinessExtensionControllerTest.php
@@ -21,6 +21,8 @@ use SnapchatForWooCommerce\Connection\WcsClient;
 use SnapchatForWooCommerce\Connection\JetpackAuthenticator;
 use SnapchatForWooCommerce\Connection\JetpackClient;
 use SnapchatForWooCommerce\Plugin;
+use SnapchatForWooCommerce\API\AdPartner\AdPartnerApi;
+use SnapchatForWooCommerce\API\AdPartner\CatalogApi;
 
 /**
  * Tests the SnapchatOrganizationsController REST API endpoints.
@@ -103,19 +105,38 @@ class SnapchatBusinessExtensionControllerTest extends WP_UnitTestCase {
 	 * Register the REST route with mocked Jetpack client.
 	 */
 	public function register_route(): void {
-		$controller = new SnapchatBusinessExtensionController(
-			new WcsClient(
-				new JetpackAuthenticator(),
-				$this->jetpack_client
+		$wcs = new WcsClient(
+			new JetpackAuthenticator(),
+			$this->jetpack_client
+		);
+		$mock_ad_partner_api = $this->createMock( AdPartnerApi::class );
+		$mock_catalog        = $this->createMock( CatalogApi::class );
+
+		// Mock `create()` to return a mock response with `get_data()`.
+		$mock_catalog->method( 'create' )->willReturn(
+			new \WP_REST_Response(
+				array(
+					'catalogs' => array(
+						array(
+							'catalog' => array(
+								'id' => 'mock-catalog-id',
+							),
+						),
+					),
+				)
 			)
 		);
+
+		$mock_ad_partner_api->catalog = $mock_catalog;
+
+		$controller = new SnapchatBusinessExtensionController( $wcs, $mock_ad_partner_api );
 		$controller->register_routes();
 	}
 
 	/**
 	 * Test: API returns errors without config id.
 	 */
-	public function test_get_config_without_config_id(): void {
+	public function test_get_config_without_config_id_and_products_token(): void {
 		$this->jetpack_client
 			->method( 'remote_request' )
 			->willReturn( array(
@@ -132,7 +153,7 @@ class SnapchatBusinessExtensionControllerTest extends WP_UnitTestCase {
 		$data = $response->get_data();
 
 		$this->assertSame( 'rest_missing_callback_param', $data['code'] );
-		$this->assertSame( 'Missing parameter(s): id', $data['message'] );
+		$this->assertSame( 'Missing parameter(s): id, products_token', $data['message'] );
 	}
 
 	/**
@@ -151,7 +172,7 @@ class SnapchatBusinessExtensionControllerTest extends WP_UnitTestCase {
 		$request->set_header( 'Content-Type', 'application/json' );
 		$request->set_body(
 			wp_json_encode(
-				array( 'id' => 'hello' )
+				array( 'id' => 'hello', 'products_token' => 'abc123' )
 			)
 		);
 
@@ -167,6 +188,7 @@ class SnapchatBusinessExtensionControllerTest extends WP_UnitTestCase {
 			'ad_acc_id'   => 'be1l1a65-e320-456f-4a49-68999aee29c5',
 			'ad_acc_name' => 'Squad 6',
 			'pixel_id'    => 'a6458d50-44a3-42e2-65e4-ed1943j59da4',
+			'catalog_id'  => 'mock-catalog-id',
 		), $data );
 		$this->assertSame( $this->options['org_id'], Options::get( OptionDefaults::ORGANIZATION_ID ) );
 		$this->assertSame( 'Seireitei', Options::get( OptionDefaults::ORGANIZATION_NAME ) );

--- a/tests/Unit/Admin/Export/Service/ProductExportServiceTest.php
+++ b/tests/Unit/Admin/Export/Service/ProductExportServiceTest.php
@@ -24,6 +24,8 @@ use SnapchatForWooCommerce\Admin\Export\Contract\ExportWriterInterface;
 use SnapchatForWooCommerce\Admin\Export\BatchExportJob;
 use SnapchatForWooCommerce\Utils\Storage\Options;
 use SnapchatForWooCommerce\Utils\Storage\OptionDefaults;
+use SnapchatForWooCommerce\Connection\WcsClient;
+use SnapchatForWooCommerce\API\AdPartner\AdPartnerApi;
 
 /**
  * @covers \SnapchatForWooCommerce\Admin\Export\Service\ProductExportService
@@ -38,6 +40,7 @@ class ProductExportServiceTest extends WP_UnitTestCase {
 	private $row_builder;
 	private $writer;
 	private $job;
+	private $api;
 
 	/**
 	 * Service under test.
@@ -53,7 +56,8 @@ class ProductExportServiceTest extends WP_UnitTestCase {
 		$this->entity_provider = $this->createMock( ExportableEntityProviderInterface::class );
 		$this->row_builder     = $this->createMock( ExportRowBuilderInterface::class );
 		$this->writer          = $this->createMock( ExportWriterInterface::class );
-		$this->job             = new BatchExportJob( $this->cache_builder, $this->entity_provider, $this->row_builder, $this->writer );
+		$this->api             = $this->createMock( AdPartnerApi::class );
+		$this->job             = new BatchExportJob( $this->cache_builder, $this->entity_provider, $this->row_builder, $this->writer, $this->api );
 
 		$this->service = new ProductExportService( $this->job );
 	}
@@ -129,7 +133,7 @@ class ProductExportServiceTest extends WP_UnitTestCase {
 		$entity_provider = new ProductEntityProvider();
 		$row_builder     = new ProductRowBuilder();
 		$writer          = new CsvExportWriter();
-		$job             = new BatchExportJob( $this->cache_builder, $entity_provider, $row_builder, $writer );
+		$job             = new BatchExportJob( $this->cache_builder, $entity_provider, $row_builder, $writer, $this->api );
 
 		$service = new ProductExportService( $job );
 

--- a/tests/Unit/Admin/Export/Writer/CsvExportWriterTest.php
+++ b/tests/Unit/Admin/Export/Writer/CsvExportWriterTest.php
@@ -7,6 +7,8 @@ namespace SnapchatForWooCommerce\Tests\Unit\Admin\Export\Writer;
 
 use WP_UnitTestCase;
 use SnapchatForWooCommerce\Admin\Export\Writer\CsvExportWriter;
+use SnapchatForWooCommerce\Utils\Storage\Options;
+use SnapchatForWooCommerce\Utils\Storage\OptionDefaults;
 
 /**
  * @covers \SnapchatForWooCommerce\Admin\Export\Writer\CsvExportWriter
@@ -72,10 +74,11 @@ class CsvExportWriterTest extends WP_UnitTestCase {
 	 * Tests that generate_url() returns a valid download URL based on file path.
 	 */
 	public function test_generate_url_returns_valid_download_link() {
+		Options::set( OptionDefaults::WCS_PRODUCTS_TOKEN, 'abc123' );
 		$file = $this->writer->create_file();
 		$url  = $this->writer->generate_url( $file );
 
-		$this->assertStringContainsString( '/wp-content/uploads/snapchat-exports/', $url );
+		$this->assertStringContainsString( '/wp-content/uploads/snapchat/', $url );
 		$this->assertStringEndsWith( '.csv', $url );
 
 		// Clean up


### PR DESCRIPTION
Closes: https://linear.app/a8c/issue/SNAPWOO-41/improve-the-submission-of-product-catalogs-to-snapchat

### Description

1. When merchant connects to Snapchat successfully, the plugin:
   - Auto-creates a Catalog
   - Auto-creates a Feed
2. Removes the "Download CSV" button.

### Testing

1. Delete all the options related to the plugin from the `wp_options` table.
2. Connect to Snapchat.
3. Wait for the CSV generation to complete.
4. Login to the Snapchat Dashboard > Assets > Catalogues, observe that the catalog is created with the feed.
5. Once Snapchat is done processing the feed, verify the product count in the feed.