### PR TITLE
SNAPWOO-46: Set availability as OUT OF STOCK and price to 0 if price is not set

### DIFF
--- a/includes/Admin/Export/RowBuilder/ProductRowBuilder.php
+++ b/includes/Admin/Export/RowBuilder/ProductRowBuilder.php
@@ -64,8 +64,8 @@ class ProductRowBuilder implements ExportRowBuilderInterface {
 			'description'  => $product->get_description(),
 			'link'         => get_permalink( $product->get_id() ),
 			'image_link'   => $image_url,
-			'availability' => $product->is_in_stock() ? 'In stock' : 'Out of stock',
-			'price'        => $price . ' ' . $currency,
+			'availability' => $product->is_in_stock() && '' !== $price ? 'In stock' : 'Out of stock',
+			'price'        => ( '' === $price ? '0' : $price ) . ' ' . $currency,
 			'gtin'         => $product->get_global_unique_id(),
 		);
 	}

--- a/includes/Admin/Export/RowBuilder/ProductRowBuilder.php
+++ b/includes/Admin/Export/RowBuilder/ProductRowBuilder.php
@@ -55,8 +55,9 @@ class ProductRowBuilder implements ExportRowBuilderInterface {
 		$image_id  = $product->get_image_id();
 		$image_url = $image_id ? wp_get_attachment_url( $image_id ) : '';
 
-		$price    = $product->get_price();
-		$currency = get_woocommerce_currency();
+		$price        = $product->get_price();
+		$is_price_set = '' !== $price;
+		$currency     = get_woocommerce_currency();
 
 		return array(
 			'id'           => (string) $product->get_id(),
@@ -64,8 +65,15 @@ class ProductRowBuilder implements ExportRowBuilderInterface {
 			'description'  => $product->get_description(),
 			'link'         => get_permalink( $product->get_id() ),
 			'image_link'   => $image_url,
-			'availability' => $product->is_in_stock() && '' !== $price ? 'In stock' : 'Out of stock',
-			'price'        => ( '' === $price ? '0' : $price ) . ' ' . $currency,
+			/**
+			 * In case the price is not set, we set the availability to 'Out of stock'
+			 * as that indicates the product is not available for purchase.
+			 *
+			 * However, if the price is explicitly set to `0`, we consider it as 'In stock'
+			 * as the product can be sold as a free product (for example, a free digital download).
+			 */
+			'availability' => $product->is_in_stock() && $is_price_set ? 'In stock' : 'Out of stock',
+			'price'        => ( $is_price_set ? $price : '0' ) . ' ' . $currency,
 			'gtin'         => $product->get_global_unique_id(),
 		);
 	}

--- a/includes/Utils/Helper.php
+++ b/includes/Utils/Helper.php
@@ -9,6 +9,7 @@
 namespace SnapchatForWooCommerce\Utils;
 
 use SnapchatForWooCommerce\Config;
+use WC_Product;
 
 /**
  * Class Helper

--- a/tests/Unit/Admin/Export/Service/ProductExportServiceTest.php
+++ b/tests/Unit/Admin/Export/Service/ProductExportServiceTest.php
@@ -125,10 +125,14 @@ class ProductExportServiceTest extends WP_UnitTestCase {
 	public function test_handle_batch_first_batch_sets_file_path_and_schedules_next(): void {
 		$product = new \WC_Product_Simple();
 		$product->set_name( 'Test Product' );
-		$product->set_price( 29.99 );
+		$product->set_regular_price( '29.99' );
 		$product->save();
 
-		Options::set( OptionDefaults::EXPORT_PRODUCT_IDS, array( $product->get_id() ) );
+		$product_2 = new \WC_Product_Simple();
+		$product_2->set_name( 'Sample Product' );
+		$product_2->save();
+
+		Options::set( OptionDefaults::EXPORT_PRODUCT_IDS, array( $product->get_id(), $product_2->get_id() ) );
 
 		$entity_provider = new ProductEntityProvider();
 		$row_builder     = new ProductRowBuilder();
@@ -153,14 +157,25 @@ class ProductExportServiceTest extends WP_UnitTestCase {
 			$csv[0]
 		);
 
+		var_dump($csv);
+
 		$this->assertEquals( (string) $product->get_id(), $csv[1][0] );
 		$this->assertEquals( 'Test Product', $csv[1][1] );
 		$this->assertEquals( '', $csv[1][2] );
 		$this->assertStringContainsString( '?product=test-product', $csv[1][3] );
 		$this->assertEquals( '', $csv[1][4] );
 		$this->assertEquals( 'In stock', $csv[1][5] );
-		$this->assertEquals( ' USD', $csv[1][6] );
+		$this->assertEquals( '29.99 USD', $csv[1][6] );
 		$this->assertEquals( '', $csv[1][7] );
+
+		$this->assertEquals( (string) $product_2->get_id(), $csv[2][0] );
+		$this->assertEquals( 'Sample Product', $csv[2][1] );
+		$this->assertEquals( '', $csv[2][2] );
+		$this->assertStringContainsString( '?product=sample-product', $csv[2][3] );
+		$this->assertEquals( '', $csv[2][4] );
+		$this->assertEquals( 'Out of stock', $csv[2][5] );
+		$this->assertEquals( '0 USD', $csv[2][6] );
+		$this->assertEquals( '', $csv[2][7] );
 
 		if ( file_exists( $file_path ) ) {
 			unlink( $file_path );


### PR DESCRIPTION
Closes: https://linear.app/a8c/issue/SNAPWOO-46/handle-products-with-no-price
Related Slack convo: https://fueled.slack.com/archives/C01TYRCJ1QD/p1755505242372059 

## Description
- If the price is not set (empty price field), then the price exported is `0 USD`, and the availability is set to `OUT OF STOCK`
- If the price is set to `0`, then the price exported is `0 USD`, and the availability is set to `IN STOCK`