### PR TITLE
SNAPWOO-47: Add `google_product_category` column to the CSV export

### DIFF
--- a/includes/Admin/Export/Contract/RowBuilderAdditionalData.php
+++ b/includes/Admin/Export/Contract/RowBuilderAdditionalData.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Defines a generic extension point for enriching export rows with additional data.
+ *
+ * Implementations of this interface can provide extra attributes beyond the
+ * core entity fields (e.g., product category, brand, or MPN). Each provider
+ * contributes a small associative array that is merged into the final export row
+ * by a row builder such as {@see ProductRowBuilder}.
+ *
+ * This generic contract allows extension of multiple entity types, keeping
+ * row builders clean and enabling optional metadata to be supplied by
+ * dedicated classes.
+ *
+ * @package SnapchatForWooCommerce\Admin\Export\Contract
+ * @since 0.1.0
+ */
+
+namespace SnapchatForWooCommerce\Admin\Export\Contract;
+
+/**
+ * Contract for providers that contribute additional export row fields.
+ *
+ * Implementations should return an associative array of scalar values keyed
+ * by the target feed's expected field names. If no data is available, return
+ * an empty array. Entity-specific sub-interfaces may provide stronger typing
+ * (e.g., {@see ProductRowBuilderAdditionalData}).
+ *
+ * @since 0.1.0
+ */
+interface RowBuilderAdditionalData {
+
+	/**
+	 * Provide additional data for an export row.
+	 *
+	 * Implementations are expected to extract relevant metadata from the entity
+	 * (e.g., taxonomy, attributes, or custom meta) and return it in a format
+	 * suitable for merging into the export row.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param mixed $entity The exportable entity (e.g., WC_Product, WC_Order).
+	 * @return array<string,scalar> Associative data to merge into the row.
+	 */
+	public function get_additional_data( $entity ): array;
+}

--- a/includes/Admin/Export/RowBuilder/ProductRowBuilder.php
+++ b/includes/Admin/Export/RowBuilder/ProductRowBuilder.php
@@ -15,6 +15,7 @@ namespace SnapchatForWooCommerce\Admin\Export\RowBuilder;
 
 use WC_Product;
 use SnapchatForWooCommerce\Admin\Export\Contract\ExportRowBuilderInterface;
+use SnapchatForWooCommerce\Admin\Export\Contract\RowBuilderAdditionalData;
 
 /**
  * Converts WooCommerce products into catalog-compatible row arrays.
@@ -29,6 +30,27 @@ use SnapchatForWooCommerce\Admin\Export\Contract\ExportRowBuilderInterface;
  * @since 0.1.0
  */
 class ProductRowBuilder implements ExportRowBuilderInterface {
+	/**
+	 * Additional data providers that can enrich the export row.
+	 *
+	 * @var RowBuilderAdditionalData[]
+	 */
+	protected $additional_data_providers = array();
+
+	/**
+	 * Constructor.
+	 *
+	 * Accepts an array of {@see RowBuilderAdditionalData} providers which will
+	 * contribute extra fields to the final row. This allows for a clean
+	 * separation between core attributes and optional enrichments.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param RowBuilderAdditionalData[] $additional_data_providers One or more providers.
+	 */
+	public function __construct( array $additional_data_providers = array() ) {
+		$this->additional_data_providers = $additional_data_providers;
+	}
 
 	/**
 	 * Builds a single exportable row from a product entity.
@@ -58,7 +80,7 @@ class ProductRowBuilder implements ExportRowBuilderInterface {
 		$price    = $product->get_price();
 		$currency = get_woocommerce_currency();
 
-		return array(
+		$row = array(
 			'id'           => (string) $product->get_id(),
 			'title'        => $product->get_name(),
 			'description'  => $product->get_description(),
@@ -68,5 +90,12 @@ class ProductRowBuilder implements ExportRowBuilderInterface {
 			'price'        => $price . ' ' . $currency,
 			'gtin'         => $product->get_global_unique_id(),
 		);
+
+		// Merge additional data from all providers.
+		foreach ( $this->additional_data_providers as $provider ) {
+			$row = array_merge( $row, $provider->get_additional_data( $product ) );
+		}
+
+		return $row;
 	}
 }

--- a/includes/Admin/Export/Writer/CsvExportWriter.php
+++ b/includes/Admin/Export/Writer/CsvExportWriter.php
@@ -124,6 +124,13 @@ class CsvExportWriter implements ExportWriterInterface {
 	 * @param string[] $row       Associative array representing a CSV row.
 	 */
 	public function append_row( string $file_path, array $row ): void {
+		$decoded_row = array_map(
+			static function ( $value ) {
+				return is_string( $value ) ? html_entity_decode( $value, ENT_QUOTES | ENT_HTML5, 'UTF-8' ) : $value;
+			},
+			$row
+		);
+
 		// Read existing content.
 		$content  = $this->fs->get_contents( $file_path );
 		$is_empty = empty( $content );
@@ -141,10 +148,10 @@ class CsvExportWriter implements ExportWriterInterface {
 		$fp = fopen( 'php://temp', 'r+' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
 
 		if ( $is_empty ) {
-			fputcsv( $fp, array_keys( $row ) );
+			fputcsv( $fp, array_keys( $decoded_row ) );
 		}
 
-		fputcsv( $fp, array_values( $row ) );
+		fputcsv( $fp, array_values( $decoded_row ) );
 		rewind( $fp );
 
 		$new_data = stream_get_contents( $fp );

--- a/includes/ServiceContainer.php
+++ b/includes/ServiceContainer.php
@@ -21,6 +21,7 @@ use SnapchatForWooCommerce\Admin\Export;
 use SnapchatForWooCommerce\Admin\ProductMeta;
 use SnapchatForWooCommerce\Tracking\ConversionEventLogger;
 use SnapchatForWooCommerce\API\AdPartner\AdPartnerApi;
+use SnapchatForWooCommerce\Utils\ProductData\ProductCategoryProvider;
 use function wc_get_logger;
 
 
@@ -103,7 +104,11 @@ final class ServiceContainer {
 					new Export\BatchExportJob(
 						new Export\Service\ProductIdCacheBuilder(),
 						new Export\EntityProvider\ProductEntityProvider(),
-						new Export\RowBuilder\ProductRowBuilder(),
+						new Export\RowBuilder\ProductRowBuilder(
+							array(
+								new ProductCategoryProvider(),
+							)
+						),
 						new Export\Writer\CsvExportWriter(),
 						AdPartnerApi::get_instance(
 							self::get( ServiceKey::WCS_CLIENT )

--- a/includes/Utils/ProductData/ProductCategoryProvider.php
+++ b/includes/Utils/ProductData/ProductCategoryProvider.php
@@ -19,6 +19,7 @@
 namespace SnapchatForWooCommerce\Utils\ProductData;
 
 use WC_Product;
+use WP_Term;
 use SnapchatForWooCommerce\Admin\Export\Contract\RowBuilderAdditionalData;
 
 /**
@@ -69,12 +70,17 @@ class ProductCategoryProvider implements RowBuilderAdditionalData {
 		$primary = array_shift( $terms );
 
 		// Build breadcrumb-style hierarchy.
-		$ancestors  = array_reverse( get_ancestors( $primary->term_id, 'product_cat' ) );
+		$ancestors = array_reverse( get_ancestors( $primary->term_id, 'product_cat' ) );
+
+		// Prime caches for all ancestor terms in a single call.
+		_prime_term_caches( $ancestors, 'product_cat' );
+
 		$categories = array();
 
 		foreach ( $ancestors as $ancestor_id ) {
 			$ancestor = get_term( $ancestor_id, 'product_cat' );
-			if ( ! is_wp_error( $ancestor ) && $ancestor ) {
+
+			if ( ! is_wp_error( $ancestor ) && $ancestor instanceof WP_Term ) {
 				$categories[] = $ancestor->name;
 			}
 		}

--- a/includes/Utils/ProductData/ProductCategoryProvider.php
+++ b/includes/Utils/ProductData/ProductCategoryProvider.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Provides the Google Product Category (GPC) field for WooCommerce products.
+ *
+ * This class inspects the WooCommerce product categories assigned to a product
+ * and derives a breadcrumb-style string representation (e.g.,
+ * "Apparel & Accessories > Clothing > Activewear"). The resulting value is
+ * returned as an associative array suitable for merging into an export row or
+ * any other product payload.
+ *
+ * By implementing {@see RowBuilderAdditionalData}, this provider can be injected
+ * into {@see ProductRowBuilder} or any similar row builder, ensuring that
+ * product category logic remains isolated, reusable, and testable.
+ *
+ * @package SnapchatForWooCommerce\Utils\ProductData
+ * @since 0.1.0
+ */
+
+namespace SnapchatForWooCommerce\Utils\ProductData;
+
+use WC_Product;
+use SnapchatForWooCommerce\Admin\Export\Contract\RowBuilderAdditionalData;
+
+/**
+ * Derives the google_product_category field from WooCommerce product categories.
+ *
+ * The provider walks the term hierarchy to build a breadcrumb-style path,
+ * ensuring that deeper category context is captured. The final string is
+ * truncated to 250 characters, in accordance with Google’s product data
+ * specification.
+ *
+ * @since 0.1.0
+ */
+class ProductCategoryProvider implements RowBuilderAdditionalData {
+
+	/**
+	 * Build the google_product_category value for a given product.
+	 *
+	 * Returns an associative array with a single key 'google_product_category'.
+	 * If the product has no categories, an empty array is returned to avoid
+	 * polluting the export row with invalid data.
+	 *
+	 * Example:
+	 * [
+	 *   'google_product_category' => 'Apparel & Accessories > Clothing > Activewear'
+	 * ]
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param WC_Product $product Product instance.
+	 * @return array<string,string> Associative array with GPC field or empty if unavailable.
+	 */
+	public function get_additional_data( $product ): array {
+		$terms = get_the_terms( $product->get_id(), 'product_cat' );
+
+		if ( empty( $terms ) || is_wp_error( $terms ) ) {
+			return array();
+		}
+
+		// Select the deepest assigned category.
+		usort(
+			$terms,
+			function ( $a, $b ) {
+				return count( get_ancestors( $b->term_id, 'product_cat' ) )
+					- count( get_ancestors( $a->term_id, 'product_cat' ) );
+			}
+		);
+
+		$primary = array_shift( $terms );
+
+		// Build breadcrumb-style hierarchy.
+		$ancestors  = array_reverse( get_ancestors( $primary->term_id, 'product_cat' ) );
+		$categories = array();
+
+		foreach ( $ancestors as $ancestor_id ) {
+			$ancestor = get_term( $ancestor_id, 'product_cat' );
+			if ( ! is_wp_error( $ancestor ) && $ancestor ) {
+				$categories[] = $ancestor->name;
+			}
+		}
+
+		$categories[] = $primary->name;
+		$gpc          = implode( ' > ', $categories );
+
+		return array(
+			'google_product_category' => substr( $gpc, 0, 250 ),
+		);
+	}
+}


### PR DESCRIPTION
Closes: https://linear.app/a8c/issue/SNAPWOO-47/add-google-product-category-to-the-product-feed

## Description

- Adds the `google_product_category` column to the CSV export.
- The recommended depth is `3`, for example: `Apparel & Accessories > Clothing > Activewear`. However, this will be the responsibility of the merchant and cannot be controlled by the plugin.