### PR TITLE
SNAPWOO-49: update the catalog name format

### DIFF
--- a/includes/Utils/Helper.php
+++ b/includes/Utils/Helper.php
@@ -134,12 +134,12 @@ class Helper {
 	public static function get_store_name( string $suffix = '' ): string {
 		$home_url   = get_home_url();
 		$clean_url  = preg_replace( '#^https?://#', '', $home_url );
-		$store_name = $clean_url . '_woocommerce_' . time();
+		$store_name = $clean_url . '_' . time();
 
 		if ( $suffix ) {
 			$store_name .= '_' . $suffix;
 		}
 
-		return $store_name;
+		return 'WooCommerce imported catalog ' . $store_name;
 	}
 }


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/SNAPWOO-49/change-name-of-catalog

## Description

Updated catalog name format to: `WooCommerce imported catalog <site-domain>_<timestamp>_<suffix>`

## Testing

1. Reconnect to Snapchat.
2. Wait for the export to finish.
3. Verify that the Catalog name in the Snapchat Dashboard has the name in the new format.