### PR TITLE
SNAPWOO-48: Conditionally create the feed

### DIFF
--- a/includes/API/Site/Controllers/SnapchatBusinessExtensionController.php
+++ b/includes/API/Site/Controllers/SnapchatBusinessExtensionController.php
@@ -241,6 +241,7 @@ class SnapchatBusinessExtensionController extends RESTBaseController {
 			$catalog = $catalog_data[0]['catalog'];
 
 			Options::set( OptionDefaults::CATALOG_ID, $catalog['id'] );
+			Options::set( OptionDefaults::CATALOG_STATUS, 'created' );
 		}
 
 		/**
@@ -405,6 +406,8 @@ class SnapchatBusinessExtensionController extends RESTBaseController {
 				Options::delete( OptionDefaults::EXPORT_FILE_PATH );
 				Options::delete( OptionDefaults::EXPORT_FILE_URL );
 				Options::delete( OptionDefaults::EXPORT_PRODUCT_IDS );
+				Options::delete( OptionDefaults::CATALOG_STATUS );
+				Options::delete( OptionDefaults::FEED_STATUS );
 				Transients::delete( TransientDefaults::PIXEL_SCRIPT );
 
 				/**

--- a/includes/API/Site/Controllers/SnapchatBusinessExtensionController.php
+++ b/includes/API/Site/Controllers/SnapchatBusinessExtensionController.php
@@ -243,7 +243,6 @@ class SnapchatBusinessExtensionController extends RESTBaseController {
 			$catalog = $catalog_data[0]['catalog'];
 
 			Options::set( OptionDefaults::CATALOG_ID, $catalog['id'] );
-			Options::set( OptionDefaults::CATALOG_STATUS, 'created' );
 		}
 
 		/**
@@ -408,7 +407,6 @@ class SnapchatBusinessExtensionController extends RESTBaseController {
 				Options::delete( OptionDefaults::EXPORT_FILE_PATH );
 				Options::delete( OptionDefaults::EXPORT_FILE_URL );
 				Options::delete( OptionDefaults::EXPORT_PRODUCT_IDS );
-				Options::delete( OptionDefaults::CATALOG_STATUS );
 				Options::delete( OptionDefaults::FEED_STATUS );
 				Transients::delete( TransientDefaults::PIXEL_SCRIPT );
 

--- a/includes/API/Site/Controllers/SnapchatBusinessExtensionController.php
+++ b/includes/API/Site/Controllers/SnapchatBusinessExtensionController.php
@@ -173,10 +173,12 @@ class SnapchatBusinessExtensionController extends RESTBaseController {
 		Options::set( OptionDefaults::CONFIG_ID, $config_id );
 
 		if ( empty( $products_token ) ) {
-			$logger = wc_get_logger();
-			$logger->warning(
-				'products_token not set. Auto product feed creation will fail.'
-			);
+			if ( Helper::is_logging_enabled() ) {
+				$logger = wc_get_logger();
+				$logger->warning(
+					'products_token not set. Auto product feed creation will fail.'
+				);
+			}
 		} else {
 			Options::set( OptionDefaults::WCS_PRODUCTS_TOKEN, $products_token );
 		}

--- a/includes/Admin/Export/Service/ProductExportService.php
+++ b/includes/Admin/Export/Service/ProductExportService.php
@@ -14,7 +14,6 @@
 
 namespace SnapchatForWooCommerce\Admin\Export\Service;
 
-use Google\Protobuf\Option;
 use SnapchatForWooCommerce\Config;
 use SnapchatForWooCommerce\Utils\Helper;
 use SnapchatForWooCommerce\Admin\Export\BatchExportJob;
@@ -400,10 +399,12 @@ class ProductExportService {
 			$response = $this->job->ad_partner_api->feed->create();
 
 			if ( is_wp_error( $response ) ) {
-				$logger = wc_get_logger();
-				$logger->alert(
-					'Feed generation failed with error code' . $response->get_error_code(),
-				);
+				if ( Helper::is_logging_enabled() ) {
+					$logger = wc_get_logger();
+					$logger->alert(
+						'Feed generation failed with error code' . $response->get_error_code(),
+					);
+				}
 			} else {
 				Options::set( OptionDefaults::FEED_STATUS, 'created' );
 			}

--- a/includes/Admin/Export/Service/ProductExportService.php
+++ b/includes/Admin/Export/Service/ProductExportService.php
@@ -393,13 +393,20 @@ class ProductExportService {
 	 * @return void
 	 */
 	public function create_feed() {
-		$response = $this->job->ad_partner_api->feed->create();
+		/**
+		 * Only create the feed if it hasn't been created yet.
+		 */
+		if ( 'empty' === Options::get( OptionDefaults::FEED_STATUS ) ) {
+			$response = $this->job->ad_partner_api->feed->create();
 
-		if ( is_wp_error( $response ) ) {
-			$logger = wc_get_logger();
-			$logger->alert(
-				'Feed generation failed with error code' . $response->get_error_code(),
-			);
+			if ( is_wp_error( $response ) ) {
+				$logger = wc_get_logger();
+				$logger->alert(
+					'Feed generation failed with error code' . $response->get_error_code(),
+				);
+			} else {
+				Options::set( OptionDefaults::FEED_STATUS, 'created' );
+			}
 		}
 	}
 }

--- a/includes/Utils/Storage/OptionDefaults.php
+++ b/includes/Utils/Storage/OptionDefaults.php
@@ -135,11 +135,25 @@ final class OptionDefaults {
 	public const CATALOG_ID = 'catalog_id';
 
 	/**
+	 * Option key indicating whether the catalog has been created.
+	 *
+	 * @since 0.1.0
+	 */
+	public const CATALOG_STATUS = 'catalog_status';
+
+	/**
 	 * Option key for the Ad Partner's Product Feed ID.
 	 *
 	 * @since 0.1.0
 	 */
 	public const PRODUCT_FEED_ID = 'product_feed_id';
+
+	/**
+	 * Option key indicating whether the feed has been created.
+	 *
+	 * @since 0.1.0
+	 */
+	public const FEED_STATUS = 'feed_status';
 
 	/**
 	 * Option key to store the full file system path of the most recent export file.
@@ -211,8 +225,10 @@ final class OptionDefaults {
 			self::PIXEL_ID                => '',
 			self::CONVERSIONS_ENABLED     => 'no',
 			self::CONVERSION_ACCESS_TOKEN => '',
+			self::CATALOG_STATUS          => 'empty',
 			self::CATALOG_ID              => '',
 			self::PRODUCT_FEED_ID         => '',
+			self::FEED_STATUS             => 'empty',
 			self::EXPORT_FILE_PATH        => '',
 			self::EXPORT_FILE_URL         => '',
 			self::EXPORT_PRODUCT_IDS      => array(),

--- a/includes/Utils/Storage/OptionDefaults.php
+++ b/includes/Utils/Storage/OptionDefaults.php
@@ -135,13 +135,6 @@ final class OptionDefaults {
 	public const CATALOG_ID = 'catalog_id';
 
 	/**
-	 * Option key indicating whether the catalog has been created.
-	 *
-	 * @since 0.1.0
-	 */
-	public const CATALOG_STATUS = 'catalog_status';
-
-	/**
 	 * Option key for the Ad Partner's Product Feed ID.
 	 *
 	 * @since 0.1.0
@@ -225,7 +218,6 @@ final class OptionDefaults {
 			self::PIXEL_ID                => '',
 			self::CONVERSIONS_ENABLED     => 'no',
 			self::CONVERSION_ACCESS_TOKEN => '',
-			self::CATALOG_STATUS          => 'empty',
 			self::CATALOG_ID              => '',
 			self::PRODUCT_FEED_ID         => '',
 			self::FEED_STATUS             => 'empty',


### PR DESCRIPTION
Closes: https://linear.app/a8c/issue/SNAPWOO-48/improve-ux-of-generate-csv-button
Related Slack convo: https://fueled.slack.com/archives/C01TYRCJ1QD/p1755531210273329

## Description

In the previous implementation, whenever a CSV was generated manually or through recurring jobs, it would trigger the creation of a feed. If the feed was already created, this process would fail, resulting in wasted HTTP resources.

In this PR, we save the status of Feed in the Options. This way, `feed->create()` is only called if the feed doesn't already exist.

As discussed in the Slack convo (linked above), we are not making any changes to the UX of the Generate CSV button.

## Testing
1. Delete all the catalogs via the Snapchat dashboard.
2. Disconnect Snapchat from the plugin.
3. Reconnect and wait for the CSV generation to finish.
4. In the Snapchat dashboard, verify that the catalog is created.
5. Edit a product, click "Regenerate CSV" and verify if this functionality is working as expected.
6. Verify that no new catalog is created in the Snapchat dashboard.