### PR TITLE
SNAPWOO-52: Fix ADD_CART Conversion on Shop loop page

### DIFF
--- a/includes/Tracking/ConversionTrackingService.php
+++ b/includes/Tracking/ConversionTrackingService.php
@@ -172,9 +172,12 @@ class ConversionTrackingService implements ServiceStatusInterface {
 	public function handle_async_add_to_cart(): void {
 		check_ajax_referer( 'capi_nonce', 'security' );
 
-		$product_id = absint( wp_unslash( $_POST['product_id'] ?? 0 ) );
-		$quantity   = absint( wp_unslash( $_POST['quantity'] ?? 0 ) );
-		$event_id   = sanitize_text_field( wp_unslash( $_POST['event_id'] ?? '' ) );
+		$raw_input  = filter_input( INPUT_POST, 'payload', FILTER_UNSAFE_RAW );
+		$raw_input  = wp_unslash( $raw_input );
+		$data       = json_decode( $raw_input, true );
+		$product_id = isset( $data['product_id'] ) ? absint( $data['product_id'] ) : 0;
+		$quantity   = isset( $data['quantity'] ) ? absint( $data['quantity'] ) : 0;
+		$event_id   = isset( $data['event_id'] ) ? sanitize_text_field( $data['event_id'] ) : '';
 
 		$this->tracker->track_add_to_cart( $product_id, $quantity, $event_id );
 	}

--- a/includes/Tracking/ConversionTrackingService.php
+++ b/includes/Tracking/ConversionTrackingService.php
@@ -175,9 +175,9 @@ class ConversionTrackingService implements ServiceStatusInterface {
 		$raw_input  = filter_input( INPUT_POST, 'payload', FILTER_UNSAFE_RAW );
 		$raw_input  = wp_unslash( $raw_input );
 		$data       = json_decode( $raw_input, true );
-		$product_id = isset( $data['product_id'] ) ? absint( $data['product_id'] ) : 0;
-		$quantity   = isset( $data['quantity'] ) ? absint( $data['quantity'] ) : 0;
-		$event_id   = isset( $data['event_id'] ) ? sanitize_text_field( $data['event_id'] ) : '';
+		$product_id = absint( $data['product_id'] ?? 0 );
+		$quantity   = absint( $data['quantity'] ?? 0 );
+		$event_id   = sanitize_text_field( $data['event_id'] ?? '' );
 
 		$this->tracker->track_add_to_cart( $product_id, $quantity, $event_id );
 	}

--- a/tests/Integration/Tracking/RemoteConversionTrackerTest.php
+++ b/tests/Integration/Tracking/RemoteConversionTrackerTest.php
@@ -103,6 +103,7 @@ class RemoteConversionTrackerTest extends WP_UnitTestCase {
 
 		$this->client->expects( $this->once() )
 			->method( 'proxy_post' )
+			->willReturn( new \WP_REST_Response( array(), 200 ) )
 			->with(
 				$this->callback( fn( $path ) => str_starts_with( $path, '/conversions/v3/pixel_456/events?access_token=token_abc' ) ),
 				$this->callback(

--- a/tests/Unit/Tracking/ConversionTrackingServiceTest.php
+++ b/tests/Unit/Tracking/ConversionTrackingServiceTest.php
@@ -8,10 +8,14 @@
 namespace SnapchatForWooCommerce\Tracking;
 
 /**
- * Override check_ajax_referer() in this namespace for testing.
+ * Override check_ajax_referer() and filter_input() in this namespace for testing.
  */
 function check_ajax_referer( $action = -1, $query_arg = false, $stop = true ) {
 	return true;
+}
+
+function filter_input( $type, $var_name, $filter = FILTER_DEFAULT, $options = [] ) {
+	return $_POST[ $var_name ] ?? null;
 }
 
 namespace SnapchatForWooCommerce\Tests\Unit\Tracking;
@@ -63,15 +67,17 @@ final class ConversionTrackingServiceTest extends WP_UnitTestCase {
 	}
 
 	public function test_handle_async_add_to_cart_requires_nonce_and_delegates(): void {
-		// Prevent wp_die from exiting the test on nonce check.
-		tests_add_filter( 'wp_die_handler', '__return_false' );
-
 		$service = new ConversionTrackingService( $this->mock_tracker );
 
-		$_POST['security']   = wp_create_nonce( 'capi_nonce' );
-		$_POST['product_id'] = 777;
-		$_POST['quantity']   = 4;
-		$_POST['event_id']   = 'uuid-999';
+		// Simulate JSON payload
+		$payload = wp_json_encode( array(
+			'product_id' => 777,
+			'quantity'   => 4,
+			'event_id'   => 'uuid-999',
+		) );
+
+		$_POST['security'] = wp_create_nonce( 'capi_nonce' );
+		$_POST['payload']  = wp_slash( $payload );
 
 		$this->mock_tracker
 			->expects( $this->once() )


### PR DESCRIPTION
Closes: https://linear.app/a8c/issue/SNAPWOO-52/conversion-is-not-sent-from-shop-loop

### Description

Fixes the bug where the `ADD_CART` conversion event wasn't tracking on the Shop page.