### PR TITLE
SNAPWOO-53: Add integration parameter for Pixel events

### DIFF
--- a/includes/Tracking/RemotePixelTracker.php
+++ b/includes/Tracking/RemotePixelTracker.php
@@ -253,6 +253,7 @@ final class RemotePixelTracker implements PixelTrackerInterface {
 					'item_ids'       => $item_ids,
 					'item_category'  => implode( ', ', array_unique( $item_categories ) ),
 					'number_items'   => $number_items,
+					'integration'    => 'woocommerce-v1',
 				)
 			)
 		);

--- a/js/src/tracking/pixel/utils.js
+++ b/js/src/tracking/pixel/utils.js
@@ -20,6 +20,7 @@ export const sendPixelEvent = ( eventName, eventParams ) => {
 
 	window.snaptr( 'track', eventName, {
 		...eventParams,
+		integration: 'woocommerce-v1',
 	} );
 };
 

--- a/tests/Unit/Admin/Export/Service/ProductExportServiceTest.php
+++ b/tests/Unit/Admin/Export/Service/ProductExportServiceTest.php
@@ -157,8 +157,6 @@ class ProductExportServiceTest extends WP_UnitTestCase {
 			$csv[0]
 		);
 
-		var_dump($csv);
-
 		$this->assertEquals( (string) $product->get_id(), $csv[1][0] );
 		$this->assertEquals( 'Test Product', $csv[1][1] );
 		$this->assertEquals( '', $csv[1][2] );

--- a/tests/e2e/specs/tracking/pixels/add_cart-event.spec.js
+++ b/tests/e2e/specs/tracking/pixels/add_cart-event.spec.js
@@ -35,6 +35,7 @@ test.describe( 'ADD_CART event', () => {
 
 			const [ , , payload ] = ADD_CART;
 
+			expect( payload.integration ).toBe( 'woocommerce-v1' );
 			expect( payload.price ).toBe( 10 );
 			expect( payload.event_id ).toMatch( anyUuidRegex );
 			expect( payload.client_dedup_id ).toMatch( anyUuidRegex );

--- a/tests/e2e/specs/tracking/pixels/page_view-event.spec.js
+++ b/tests/e2e/specs/tracking/pixels/page_view-event.spec.js
@@ -29,6 +29,9 @@ test.describe( 'PAGE_VIEW event', () => {
 				const events = await page.evaluate( () => window.snaptr.queue );
 				const PAGE_VIEW = findSnaptrEvent( events, 'PAGE_VIEW' );
 				expect( PAGE_VIEW ).not.toBe( null );
+
+				const [ , , payload ] = PAGE_VIEW;
+				expect( payload.integration ).toBe( 'woocommerce-v1' );
 			} );
 		}
 

--- a/tests/e2e/specs/tracking/pixels/purchase-event.spec.js
+++ b/tests/e2e/specs/tracking/pixels/purchase-event.spec.js
@@ -84,6 +84,7 @@ test.describe( 'PURCHASE event', () => {
 			expect( PURCHASE ).not.toBe( null );
 
 			const [ , , payload ] = PURCHASE;
+			expect( payload.integration ).toBe( 'woocommerce-v1' );
 			expect( payload.price ).toBe( '40.00' );
 			expect( payload.currency ).toBe( 'USD' );
 			expect( payload.event_id ).toMatch( orderKeyRegex );

--- a/tests/e2e/specs/tracking/pixels/start_checkout-event.spec.js
+++ b/tests/e2e/specs/tracking/pixels/start_checkout-event.spec.js
@@ -24,6 +24,7 @@ async function checkoutAssertions( page ) {
 
 	const [ , , payload ] = START_CHECKOUT;
 
+	expect( payload.integration ).toBe( 'woocommerce-v1' );
 	expect( payload.price ).toBe( '40.00' );
 	expect( payload.currency ).toBe( 'USD' );
 	expect( payload.item_ids ).toEqual( [ '10', '11' ] );

--- a/tests/e2e/specs/tracking/pixels/view_content-event.spec.js
+++ b/tests/e2e/specs/tracking/pixels/view_content-event.spec.js
@@ -25,6 +25,7 @@ test.describe( 'VIEW_CONTENT event', () => {
 
 			const [ , , payload ] = VIEW_CONTENT;
 
+			expect( payload.integration ).toBe( 'woocommerce-v1' );
 			expect( payload.price ).toBe( 15 );
 			expect( payload.currency ).toBe( 'USD' );
 			expect( payload.item_ids ).toContain( 11 );
@@ -47,6 +48,7 @@ test.describe( 'VIEW_CONTENT event', () => {
 
 			const [ , , payload ] = VIEW_CONTENT;
 
+			expect( payload.integration ).toBe( 'woocommerce-v1' );
 			expect( payload.price ).toBe( 15 );
 			expect( payload.currency ).toBe( 'USD' );
 			expect( payload.item_ids ).toContain( 11 );
@@ -77,6 +79,7 @@ test.describe( 'VIEW_CONTENT event', () => {
 
 			const [ , , payload ] = VIEW_CONTENT;
 
+			expect( payload.integration ).toBe( 'woocommerce-v1' );
 			expect( payload.price ).toBe( 15 );
 			expect( payload.currency ).toBe( 'USD' );
 			expect( payload.item_ids ).toContain( 11 );


### PR DESCRIPTION
Closes: https://linear.app/a8c/issue/SNAPWOO-53/pixel-is-missing-the-integration-parameter

## Description
- Adds the `integration` parameter for all payloads.

## Testing
- Ensure that all pixel events send the `integration` parameter with the `woocommerce-v1` value.