### PR TITLE
Compatibility testing with WC 10.2

### DIFF
--- a/snapchat-for-woocommerce.php
+++ b/snapchat-for-woocommerce.php
@@ -10,8 +10,8 @@
  * Requires Plugins: woocommerce
  * Requires PHP: 7.4
  * Requires at least: 6.7
- * WC requires at least: 9.9
- * WC tested up to: 10.1
+ * WC requires at least: 10.0
+ * WC tested up to: 10.2
  *
  * License: GNU General Public License v3.0
  * License URI: http://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION

---
### Changes proposed in this Pull Request:

- Bump WooCommerce "tested up to" version 10.2
- Bump WooCommerce minimum supported version to 10.0


Closes https://linear.app/a8c/issue/SNAPWOO-55/compatibility-testing-with-woo-102-beta


### Steps to test the changes in this Pull Request:

1. Run the e2e test using GitHub action to test this PR 
2. All tests should be passed. 

### Changelog entry

> Dev - Bump WooCommerce "tested up to" version 10.2.
> Dev - Bump WooCommerce minimum supported version to 10.0. 

