### PR TITLE
SNAPWOO-54: Add setting to collect PII

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,7 +44,7 @@ module.exports = {
 	rules: {
 		'@wordpress/i18n-text-domain': [
 			'error',
-			{ allowedTextDomain: 'snapchat-for-woo' },
+			{ allowedTextDomain: 'snapchat-for-woocommerce' },
 		],
 		'@wordpress/no-unsafe-wp-apis': 1,
 		'react/react-in-jsx-scope': 'off',

--- a/includes/API/Site/Controllers/SettingsController.php
+++ b/includes/API/Site/Controllers/SettingsController.php
@@ -77,14 +77,23 @@ class SettingsController extends RESTBaseController {
 	 * @return WP_REST_Response
 	 */
 	public function set_settings( $request ) {
-		$capi_token = null;
+		$capi_token  = null;
+		$collect_pii = null;
 
 		if ( isset( $request['capi_enabled'] ) ) {
 			$capi_token = rest_sanitize_boolean( $request['capi_enabled'] );
 		}
 
+		if ( isset( $request['collect_pii'] ) ) {
+			$collect_pii = rest_sanitize_boolean( $request['collect_pii'] );
+		}
+
 		if ( ! is_null( $capi_token ) ) {
 			Options::set( OptionDefaults::CONVERSIONS_ENABLED, $capi_token ? 'yes' : 'no' );
+		}
+
+		if ( ! is_null( $collect_pii ) ) {
+			Options::set( OptionDefaults::COLLECT_PII, $collect_pii ? 'yes' : 'no' );
 		}
 
 		return rest_ensure_response(
@@ -108,6 +117,7 @@ class SettingsController extends RESTBaseController {
 		return rest_ensure_response(
 			array(
 				'capi_enabled'          => 'yes' === Options::get( OptionDefaults::CONVERSIONS_ENABLED ),
+				'collect_pii'           => 'yes' === Options::get( OptionDefaults::COLLECT_PII ),
 				'trigger_export'        => ! file_exists( $csv_path ) && Helper::has_products() && (int) $timestamp <= ( time() - DAY_IN_SECONDS ),
 				'last_export_timestamp' => Helper::get_formatted_timestamp( $timestamp ),
 				'export_file_url'       => file_exists( $csv_path ) ? Options::get( OptionDefaults::EXPORT_FILE_URL ) : '',

--- a/includes/Connection/WcsClient.php
+++ b/includes/Connection/WcsClient.php
@@ -219,8 +219,8 @@ final class WcsClient {
 		}
 
 		return new WP_Error(
-			'wcs_error',
-			__( 'WCS request failed', 'snapchat-for-woocommerce' ),
+			Helper::with_prefix( 'request_failed' ),
+			__( 'Request failed', 'snapchat-for-woocommerce' ),
 			$response
 		);
 	}

--- a/includes/Tracking/RemoteConversionTracker.php
+++ b/includes/Tracking/RemoteConversionTracker.php
@@ -303,6 +303,7 @@ class RemoteConversionTracker implements ConversionTrackerInterface {
 
 			if ( is_wp_error( $response ) ) {
 				$body       = json_decode( wp_remote_retrieve_body( $response->get_error_data() ), true );
+				$body       = Helper::deep_replace_double_quotes( $body );
 				$error_data = $response->get_error_data();
 				$status     = $error_data['response']['code'];
 				$message    = $response->get_error_message();

--- a/includes/Tracking/RemoteConversionTracker.php
+++ b/includes/Tracking/RemoteConversionTracker.php
@@ -302,15 +302,17 @@ class RemoteConversionTracker implements ConversionTrackerInterface {
 			$event = $event_payload['event_name'] ?? '';
 
 			if ( is_wp_error( $response ) ) {
+				$body       = json_decode( wp_remote_retrieve_body( $response->get_error_data() ), true );
 				$error_data = $response->get_error_data();
 				$status     = $error_data['response']['code'];
-				$message    = $error_data['response']['message'];
+				$message    = $response->get_error_message();
 
 				$info = array(
-					'context' => 'tracking',
-					'payload' => $payload,
-					'args'    => $args,
-					'error'   => $message,
+					'context'    => 'tracking',
+					'payload'    => $body,
+					'args'       => $args,
+					'error'      => $message,
+					'error_data' => $body,
 				);
 			} else {
 				$status = $response->get_status();

--- a/includes/Tracking/RemotePixelTracker.php
+++ b/includes/Tracking/RemotePixelTracker.php
@@ -17,8 +17,8 @@ use SnapchatForWooCommerce\Utils\Storage\OptionDefaults;
 use SnapchatForWooCommerce\Utils\Storage\Transients;
 use SnapchatForWooCommerce\Utils\Storage\TransientDefaults;
 use SnapchatForWooCommerce\Tracking\Consent;
+use SnapchatForWooCommerce\Utils\UserIdentifier;
 use SnapchatForWooCommerce\Config;
-use WC_Product;
 
 /**
  * Fetches and injects Snapchat pixel tracking code into WooCommerce frontend pages.
@@ -242,20 +242,22 @@ final class RemotePixelTracker implements PixelTrackerInterface {
 			}
 		}
 
+		$payload = array(
+			'price'          => $total,
+			'currency'       => $currency,
+			'event_id'       => $order_key,
+			'transaction_id' => $order_key,
+			'item_ids'       => $item_ids,
+			'item_category'  => implode( ', ', array_unique( $item_categories ) ),
+			'number_items'   => $number_items,
+			'integration'    => 'woocommerce-v1',
+		);
+
+		UserIdentifier::add_user_details( $payload );
+
 		$tracking_data = sprintf(
 			'snaptr("track", "PURCHASE", %s);',
-			wp_json_encode(
-				array(
-					'price'          => $total,
-					'currency'       => $currency,
-					'event_id'       => $order_key,
-					'transaction_id' => $order_key,
-					'item_ids'       => $item_ids,
-					'item_category'  => implode( ', ', array_unique( $item_categories ) ),
-					'number_items'   => $number_items,
-					'integration'    => 'woocommerce-v1',
-				)
-			)
+			wp_json_encode( $payload )
 		);
 
 		wp_add_inline_script( Config::ASSET_HANDLE_PREFIX . 'tracking', $tracking_data );

--- a/includes/Tracking/RemotePixelTracker.php
+++ b/includes/Tracking/RemotePixelTracker.php
@@ -16,6 +16,7 @@ use SnapchatForWooCommerce\Utils\Storage\Options;
 use SnapchatForWooCommerce\Utils\Storage\OptionDefaults;
 use SnapchatForWooCommerce\Utils\Storage\Transients;
 use SnapchatForWooCommerce\Utils\Storage\TransientDefaults;
+use SnapchatForWooCommerce\Utils\Storage;
 use SnapchatForWooCommerce\Tracking\Consent;
 use SnapchatForWooCommerce\Utils\UserIdentifier;
 use SnapchatForWooCommerce\Config;
@@ -253,7 +254,9 @@ final class RemotePixelTracker implements PixelTrackerInterface {
 			'integration'    => 'woocommerce-v1',
 		);
 
-		UserIdentifier::add_user_details( $payload );
+		if ( Storage\Helper::is_collect_pii_enabled() ) {
+			UserIdentifier::add_user_details( $payload );
+		}
 
 		$tracking_data = sprintf(
 			'snaptr("track", "PURCHASE", %s);',

--- a/includes/Utils/Helper.php
+++ b/includes/Utils/Helper.php
@@ -188,7 +188,7 @@ class Helper {
 	 * @param array $data Response array that is recursively processed.
 	 * @return array Sanitized array with double quotes replaced by single quotes.
 	 */
-	public static function deep_replace_double_quotes( $data ): array {
+	public static function deep_replace_double_quotes( $data ) {
 		if ( is_array( $data ) ) {
 			foreach ( $data as $key => $value ) {
 				$data[ $key ] = self::deep_replace_double_quotes( $value );
@@ -206,9 +206,11 @@ class Helper {
 		}
 
 		if ( is_string( $data ) ) {
+			// Replace all double quotes with single quotes.
 			return str_replace( '"', "'", $data );
 		}
 
+		// Return scalars (int, float, bool, null) as-is.
 		return $data;
 	}
 }

--- a/includes/Utils/Helper.php
+++ b/includes/Utils/Helper.php
@@ -175,4 +175,40 @@ class Helper {
 		// 32-bit PHP: fallback to seconds to avoid integer overflow.
 		return time();
 	}
+
+	/**
+	 * Recursively replaces double quotes with single quotes in strings within an array or object.
+	 *
+	 * Sometimes Reddit API responses contain JSON strings that contain encoded double quotes,
+	 * that breaks WooCommerce logger, resulting to uglified output instead of pretty print.
+	 * This function helps sanitize such data before logging.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param array $data Response array that is recursively processed.
+	 * @return array Sanitized array with double quotes replaced by single quotes.
+	 */
+	public static function deep_replace_double_quotes( $data ): array {
+		if ( is_array( $data ) ) {
+			foreach ( $data as $key => $value ) {
+				$data[ $key ] = self::deep_replace_double_quotes( $value );
+			}
+
+			return $data;
+		}
+
+		if ( is_object( $data ) ) {
+			foreach ( $data as $key => $value ) {
+				$data->$key = self::deep_replace_double_quotes( $value );
+			}
+
+			return $data;
+		}
+
+		if ( is_string( $data ) ) {
+			return str_replace( '"', "'", $data );
+		}
+
+		return $data;
+	}
 }

--- a/includes/Utils/Storage/Helper.php
+++ b/includes/Utils/Storage/Helper.php
@@ -3,7 +3,7 @@
  * Utility helper methods for interacting with Ad Partner plugin options.
  *
  * Provides convenience wrappers for common option checks and transformations.
- * This class centralizes logic related to frequently used option values, 
+ * This class centralizes logic related to frequently used option values,
  * ensuring consistent behavior across the codebase.
  *
  * @package SnapchatForWooCommerce\Utils\Storage
@@ -16,7 +16,7 @@ namespace SnapchatForWooCommerce\Utils\Storage;
  * Static utility methods for option handling.
  *
  * Contains reusable helper functions that operate on WordPress options
- * defined in {@see OptionDefaults}. These methods simplify checking 
+ * defined in {@see OptionDefaults}. These methods simplify checking
  * and interpreting stored values.
  *
  * @since 0.1.0
@@ -26,7 +26,7 @@ final class Helper {
 	/**
 	 * Determines whether Personally Identifiable Information (PII) collection is enabled.
 	 *
-	 * Checks the {@see OptionDefaults::COLLECT_PII} option to verify if PII 
+	 * Checks the {@see OptionDefaults::COLLECT_PII} option to verify if PII
 	 * collection is currently allowed. Returns `true` if enabled, `false` otherwise.
 	 *
 	 * @since 0.1.0

--- a/includes/Utils/Storage/Helper.php
+++ b/includes/Utils/Storage/Helper.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Utility helper methods for interacting with Ad Partner plugin options.
+ *
+ * Provides convenience wrappers for common option checks and transformations.
+ * This class centralizes logic related to frequently used option values, 
+ * ensuring consistent behavior across the codebase.
+ *
+ * @package SnapchatForWooCommerce\Utils\Storage
+ * @since 0.1.0
+ */
+
+namespace SnapchatForWooCommerce\Utils\Storage;
+
+/**
+ * Static utility methods for option handling.
+ *
+ * Contains reusable helper functions that operate on WordPress options
+ * defined in {@see OptionDefaults}. These methods simplify checking 
+ * and interpreting stored values.
+ *
+ * @since 0.1.0
+ */
+final class Helper {
+
+	/**
+	 * Determines whether Personally Identifiable Information (PII) collection is enabled.
+	 *
+	 * Checks the {@see OptionDefaults::COLLECT_PII} option to verify if PII 
+	 * collection is currently allowed. Returns `true` if enabled, `false` otherwise.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @return bool Whether PII collection is enabled.
+	 */
+	public static function is_collect_pii_enabled(): bool {
+		return 'yes' === Options::get( OptionDefaults::COLLECT_PII );
+	}
+}

--- a/includes/Utils/Storage/OptionDefaults.php
+++ b/includes/Utils/Storage/OptionDefaults.php
@@ -128,6 +128,13 @@ final class OptionDefaults {
 	public const CONVERSION_ACCESS_TOKEN = 'conversion_access_token';
 
 	/**
+	 * Option key that toggles whether Personally Identifiable Information (PII) is collected.
+	 *
+	 * @since 0.1.0
+	 */
+	public const COLLECT_PII = 'collect_pii';
+
+	/**
 	 * Option key for the Ad Partner's Catalog ID.
 	 *
 	 * @since 0.1.0
@@ -218,6 +225,7 @@ final class OptionDefaults {
 			self::PIXEL_ID                => '',
 			self::CONVERSIONS_ENABLED     => 'no',
 			self::CONVERSION_ACCESS_TOKEN => '',
+			self::COLLECT_PII             => 'yes',
 			self::CATALOG_ID              => '',
 			self::PRODUCT_FEED_ID         => '',
 			self::FEED_STATUS             => 'empty',

--- a/includes/Utils/UserIdentifier.php
+++ b/includes/Utils/UserIdentifier.php
@@ -1,9 +1,21 @@
 <?php
 /**
- * Extracts and formats user identifiers for CAPI matching.
+ * Extracts and formats user identifiers for Conversions API (CAPI) matching.
  *
- * Gathers client IP, user agent, Snapchat click ID (ScCid),
- * and sc_cookie1 for better attribution in server-side events.
+ * This utility class normalizes, sanitizes, and hashes personally identifiable
+ * information (PII) collected during WooCommerce transactions. The output is
+ * used as the `user_data` structure in server-side Conversions API payloads,
+ * improving event attribution and match rates.
+ *
+ * Identifiers are processed according to the Snapchat CAPI specification:
+ * - IP address and user agent (raw values, not hashed).
+ * - sc_click_id (query param) and sc_cookie1 (pixel cookie).
+ * - Customer details (email, phone, first/last name, city, postal code, country).
+ *
+ * All personal identifiers (em, ph, fn, ln, ct, zp, country) are normalized
+ * and hashed with SHA-256, as required by the API spec.
+ *
+ * @see https://developers.snap.com/api/marketing-api/Conversions-API/Parameters#user-data-parameters
  *
  * @package SnapchatForWooCommerce\Utils
  * @since 0.1.0
@@ -22,12 +34,10 @@ namespace SnapchatForWooCommerce\Utils;
 final class UserIdentifier {
 
 	/**
-	 * Returns a user_data array for CAPI payloads.
+	 * Generates the complete `user_data` array used in event payloads.
 	 *
-	 * Includes:
-	 * - IP address and user agent (from server)
-	 * - `sc_click_id` from cookie or session
-	 * - `sc_cookie1` from `_scid` cookie
+	 * Combines IP address, user agent, Snap cookies/click IDs into a
+	 * single associative array.
 	 *
 	 * @since 0.1.0
 	 *
@@ -35,6 +45,81 @@ final class UserIdentifier {
 	 */
 	public static function get_user_data(): array {
 		$data = array();
+
+		self::add_ip_address( $data );
+		self::add_user_agent( $data );
+		self::add_sc_cookie( $data );
+		self::add_click_id( $data );
+
+		if ( is_order_received_page() ) {
+			// ⚠️ Values are only extracted on the WooCommerce order-received page.
+			self::add_user_details( $data );
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Adds the Snapchat click ID (sc_click_id) if present.
+	 *
+	 * Extracted from the `ScCid` cookie set when a user clicks on a Snapchat ad.
+	 * Used for click-through attribution.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param array<string,mixed> $data Reference to the user_data array.
+	 * @return void
+	 */
+	private static function add_click_id( array &$data ): void {
+		if ( isset( $_COOKIE['ScCid'] ) ) {
+			$data['sc_click_id'] = sanitize_text_field( wp_unslash( $_COOKIE['ScCid'] ) );
+		}
+	}
+
+	/**
+	 * Adds the Snapchat cookie (sc_cookie1) if present.
+	 *
+	 * The `_scid` cookie is set by the Snapchat Pixel on the client side.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param array<string,mixed> $data Reference to the user_data array.
+	 * @return void
+	 */
+	private static function add_sc_cookie( array &$data ): void {
+		if ( isset( $_COOKIE['_scid'] ) ) {
+			$data['sc_cookie1'] = sanitize_text_field( wp_unslash( $_COOKIE['_scid'] ) );
+		}
+	}
+
+	/**
+	 * Adds the client user agent string.
+	 *
+	 * Extracted from the current HTTP request. Passed as-is (not hashed).
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param array<string,mixed> $data Reference to the user_data array.
+	 * @return void
+	 */
+	private static function add_user_agent( array &$data ): void {
+		if ( isset( $_SERVER['HTTP_USER_AGENT'] ) ) {
+			$data['client_user_agent'] = sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) );
+		}
+	}
+
+	/**
+	 * Adds the client IP address.
+	 *
+	 * Respects proxy/CDN headers (Cloudflare, X-Forwarded-For)
+	 * and falls back to REMOTE_ADDR. Passed as-is (not hashed).
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param array<string,mixed> $data Reference to the user_data array.
+	 * @return void
+	 */
+	private static function add_ip_address( array &$data ): void {
 		$ip   = '';
 
 		if ( isset( $_SERVER['HTTP_CF_CONNECTING_IP'] ) ) {
@@ -50,19 +135,91 @@ final class UserIdentifier {
 		if ( $ip ) {
 			$data['client_ip_address'] = $ip;
 		}
+	}
 
-		if ( isset( $_SERVER['HTTP_USER_AGENT'] ) ) {
-			$data['client_user_agent'] = sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) );
+	/**
+	 * Extracts and normalizes customer billing details for CAPI matching.
+	 *
+	 * Supported identifiers:
+	 * - em      > Email address (lowercased, trimmed, SHA-256 hashed).
+	 * - ph      > Phone number (digits only, SHA-256 hashed).
+	 * - fn      > First name (lowercase UTF-8, punctuation removed, SHA-256 hashed).
+	 * - ln      > Last name (lowercase UTF-8, punctuation removed, SHA-256 hashed).
+	 * - ct      > City (lowercase, punctuation/spaces removed, SHA-256 hashed).
+	 * - zp      > Postal code (normalized by country rules, SHA-256 hashed).
+	 *              - US: first 5 digits.
+	 *              - GB: area + district + sector (excludes unit).
+	 * - country > ISO-2 country code (lowercase, SHA-256 hashed).
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param array<string,mixed> $data Reference to the user_data array.
+	 */
+	private static function add_user_details( array &$data ): void {
+		$order_id = (int) get_query_var( 'order-received' );
+		$order    = wc_get_order( $order_id );
+
+		if ( ! $order instanceof \WC_Order ) {
+			return;
 		}
 
-		if ( isset( $_COOKIE['_scid'] ) ) {
-			$data['sc_cookie1'] = sanitize_text_field( wp_unslash( $_COOKIE['_scid'] ) );
+		$email      = $order->get_billing_email();
+		$phone      = $order->get_billing_phone();
+		$first_name = $order->get_billing_first_name();
+		$last_name  = $order->get_billing_last_name();
+		$city       = $order->get_billing_city();
+		$zip        = $order->get_billing_postcode();
+		$country    = $order->get_billing_country();
+
+		if ( $email ) {
+			$normalized = strtolower( trim( $email ) );
+			$data['em'] = hash( 'sha256', $normalized );
 		}
 
-		if ( isset( $_COOKIE['ScCid'] ) ) {
-			$data['sc_click_id'] = sanitize_text_field( wp_unslash( $_COOKIE['ScCid'] ) );
+		if ( $phone ) {
+			$normalized = preg_replace( '/\D+/', '', $phone );
+			$data['ph'] = hash( 'sha256', strtolower( $normalized ) );
 		}
 
-		return $data;
+		if ( $first_name ) {
+			$normalized = mb_strtolower( $first_name, 'UTF-8' );
+			$normalized = preg_replace( '/[[:punct:]]/u', '', $normalized );
+			$data['fn'] = hash( 'sha256', $normalized );
+		}
+
+		if ( $last_name ) {
+			$normalized = mb_strtolower( $last_name, 'UTF-8' );
+			$normalized = preg_replace( '/[[:punct:]]/u', '', $normalized );
+			$data['ln'] = hash( 'sha256', $normalized );
+		}
+
+		if ( $city ) {
+			$normalized = mb_strtolower( $city, 'UTF-8' );
+			$normalized = preg_replace( '/[[:punct:]\s]+/u', '', $normalized );
+			$data['ct'] = hash( 'sha256', $normalized );
+		}
+
+		if ( $zip ) {
+			$normalized = mb_strtolower( $zip, 'UTF-8' );
+			$normalized = preg_replace( '/[\s\-]+/', '', $normalized );
+
+			if ( 'US' === $country ) {
+				// US: only first 5 digits.
+				$normalized = substr( $normalized, 0, 5 );
+			} elseif ( 'GB' === $country ) {
+				// UK: area + district + sector (strip unit part)
+				// Example: SW1A1AA → sw1a1
+				if ( preg_match( '/^([a-z]{1,2}\d[a-z\d]?\d?)/i', $normalized, $matches ) ) {
+					$normalized = strtolower( $matches[1] );
+				}
+			}
+
+			$data['zp'] = hash( 'sha256', $normalized );
+		}
+
+		if ( $country ) {
+			$normalized = strtolower( $country );
+			$data['country'] = hash( 'sha256', $normalized );
+		}
 	}
 }

--- a/includes/Utils/UserIdentifier.php
+++ b/includes/Utils/UserIdentifier.php
@@ -122,7 +122,7 @@ final class UserIdentifier {
 	 * @return void
 	 */
 	private static function add_ip_address( array &$data ): void {
-		$ip   = '';
+		$ip = '';
 
 		if ( isset( $_SERVER['HTTP_CF_CONNECTING_IP'] ) ) {
 			$ip = sanitize_text_field( wp_unslash( $_SERVER['HTTP_CF_CONNECTING_IP'] ) );
@@ -210,7 +210,7 @@ final class UserIdentifier {
 				$normalized = substr( $normalized, 0, 5 );
 			} elseif ( 'GB' === $country ) {
 				// UK: area + district + sector (strip unit part)
-				// Example: SW1A1AA → sw1a1
+				// Example: SW1A1AA → sw1a1.
 				if ( preg_match( '/^([a-z]{1,2}\d[a-z\d]?\d?)/i', $normalized, $matches ) ) {
 					$normalized = strtolower( $matches[1] );
 				}
@@ -220,7 +220,7 @@ final class UserIdentifier {
 		}
 
 		if ( $country ) {
-			$normalized = strtolower( $country );
+			$normalized      = strtolower( $country );
 			$data['country'] = hash( 'sha256', $normalized );
 		}
 	}

--- a/includes/Utils/UserIdentifier.php
+++ b/includes/Utils/UserIdentifier.php
@@ -23,6 +23,8 @@
 
 namespace SnapchatForWooCommerce\Utils;
 
+use SnapchatForWooCommerce\Utils\Storage;
+
 /**
  * Builds the user_data structure for CAPI event payloads.
  *
@@ -51,7 +53,7 @@ final class UserIdentifier {
 		self::add_sc_cookie( $data );
 		self::add_click_id( $data );
 
-		if ( is_order_received_page() ) {
+		if ( is_order_received_page() && Storage\Helper::is_collect_pii_enabled() ) {
 			// ⚠️ Values are only extracted on the WooCommerce order-received page.
 			self::add_user_details( $data );
 		}

--- a/includes/Utils/UserIdentifier.php
+++ b/includes/Utils/UserIdentifier.php
@@ -155,7 +155,7 @@ final class UserIdentifier {
 	 *
 	 * @param array<string,mixed> $data Reference to the user_data array.
 	 */
-	private static function add_user_details( array &$data ): void {
+	public static function add_user_details( array &$data ): void {
 		$order_id = (int) get_query_var( 'order-received' );
 		$order    = wc_get_order( $order_id );
 

--- a/js/src/components/account-card/index.js
+++ b/js/src/components/account-card/index.js
@@ -27,7 +27,7 @@ export const APPEARANCE = {
 const snapchatLogo = (
 	<img
 		src={ snapchatLogoURL }
-		alt={ __( 'Snapchat Logo', 'snapchat-for-woo' ) }
+		alt={ __( 'Snapchat Logo', 'snapchat-for-woocommerce' ) }
 		width="40"
 		height="40"
 	/>
@@ -36,7 +36,7 @@ const snapchatLogo = (
 const wpLogo = (
 	<img
 		src={ wpLogoURL }
-		alt={ __( 'WordPress.com Logo', 'snapchat-for-woo' ) }
+		alt={ __( 'WordPress.com Logo', 'snapchat-for-woocommerce' ) }
 		width="40"
 		height="40"
 	/>
@@ -50,7 +50,7 @@ const appearanceDict = {
 	},
 	[ APPEARANCE.SNAPCHAT ]: {
 		icon: snapchatLogo,
-		title: __( 'Snapchat', 'snapchat-for-woo' ),
+		title: __( 'Snapchat', 'snapchat-for-woocommerce' ),
 	},
 };
 

--- a/js/src/components/app-spinner/index.js
+++ b/js/src/components/app-spinner/index.js
@@ -17,7 +17,7 @@ const AppSpinner = () => {
 		<div
 			className="sfw-app-spinner"
 			role="status"
-			aria-label={ __( 'Loading…', 'snapchat-for-woo' ) }
+			aria-label={ __( 'Loading…', 'snapchat-for-woocommerce' ) }
 		>
 			<Spinner />
 		</div>

--- a/js/src/components/connected-icon-label/index.js
+++ b/js/src/components/connected-icon-label/index.js
@@ -23,7 +23,7 @@ const ConnectedIconLabel = ( props ) => {
 			<FlexItem>
 				<GridiconCheckmarkCircle />
 			</FlexItem>
-			<FlexItem>{ __( 'Connected', 'snapchat-for-woo' ) }</FlexItem>
+			<FlexItem>{ __( 'Connected', 'snapchat-for-woocommerce' ) }</FlexItem>
 		</Flex>
 	);
 };

--- a/js/src/components/connected-icon-label/index.js
+++ b/js/src/components/connected-icon-label/index.js
@@ -23,7 +23,9 @@ const ConnectedIconLabel = ( props ) => {
 			<FlexItem>
 				<GridiconCheckmarkCircle />
 			</FlexItem>
-			<FlexItem>{ __( 'Connected', 'snapchat-for-woocommerce' ) }</FlexItem>
+			<FlexItem>
+				{ __( 'Connected', 'snapchat-for-woocommerce' ) }
+			</FlexItem>
 		</Flex>
 	);
 };

--- a/js/src/components/help-icon-button/index.js
+++ b/js/src/components/help-icon-button/index.js
@@ -40,7 +40,7 @@ const HelpIconButton = ( { eventContext } ) => {
 			} }
 		>
 			<GridiconHelpOutline />
-			{ __( 'Help', 'snapchat-for-woo' ) }
+			{ __( 'Help', 'snapchat-for-woocommerce' ) }
 		</AppButton>
 	);
 };

--- a/js/src/components/onboarding-success-modal/index.js
+++ b/js/src/components/onboarding-success-modal/index.js
@@ -40,7 +40,7 @@ const OnboardingSuccessModal = () => {
 					variant="secondary"
 					onClick={ handleCloseModal }
 				>
-					{ __( 'Close', 'snapchat-for-woo' ) }
+					{ __( 'Close', 'snapchat-for-woocommerce' ) }
 				</AppButton>,
 			] }
 		>
@@ -49,7 +49,7 @@ const OnboardingSuccessModal = () => {
 					<FlexItem>
 						<img
 							src={ wooLogoURL }
-							alt={ __( 'WooCommerce Logo', 'snapchat-for-woo' ) }
+							alt={ __( 'WooCommerce Logo', 'snapchat-for-woocommerce' ) }
 							width="187.5"
 						/>
 					</FlexItem>
@@ -57,7 +57,7 @@ const OnboardingSuccessModal = () => {
 					<FlexItem>
 						<img
 							src={ snapchatLogoURL }
-							alt={ __( 'Snapchat Logo', 'snapchat-for-woo' ) }
+							alt={ __( 'Snapchat Logo', 'snapchat-for-woocommerce' ) }
 							width="123"
 						/>
 					</FlexItem>
@@ -68,13 +68,13 @@ const OnboardingSuccessModal = () => {
 				<h2 className="sfw-onboarding-success-modal__title">
 					{ __(
 						'You’ve successfully set up Snapchat for WooCommerce! 🎉',
-						'snapchat-for-woo'
+						'snapchat-for-woocommerce'
 					) }
 				</h2>
 				<div className="sfw-onboarding-success-modal__description">
 					{ __(
 						'Your store is now connected to Snapchat. You can start running ads, track performance, and reach Snapchat users with your WooCommerce products.',
-						'snapchat-for-woo'
+						'snapchat-for-woocommerce'
 					) }
 				</div>
 			</div>

--- a/js/src/components/onboarding-success-modal/index.js
+++ b/js/src/components/onboarding-success-modal/index.js
@@ -49,7 +49,10 @@ const OnboardingSuccessModal = () => {
 					<FlexItem>
 						<img
 							src={ wooLogoURL }
-							alt={ __( 'WooCommerce Logo', 'snapchat-for-woocommerce' ) }
+							alt={ __(
+								'WooCommerce Logo',
+								'snapchat-for-woocommerce'
+							) }
 							width="187.5"
 						/>
 					</FlexItem>
@@ -57,7 +60,10 @@ const OnboardingSuccessModal = () => {
 					<FlexItem>
 						<img
 							src={ snapchatLogoURL }
-							alt={ __( 'Snapchat Logo', 'snapchat-for-woocommerce' ) }
+							alt={ __(
+								'Snapchat Logo',
+								'snapchat-for-woocommerce'
+							) }
 							width="123"
 						/>
 					</FlexItem>

--- a/js/src/components/snapchat-account-card/account-details.js
+++ b/js/src/components/snapchat-account-card/account-details.js
@@ -21,21 +21,21 @@ const AccountDetails = () => {
 		<div className="sfw-snapchat-account-details">
 			{ organizationName && (
 				<p>
-					{ __( 'Organization:', 'snapchat-for-woo' ) }{ ' ' }
+					{ __( 'Organization:', 'snapchat-for-woocommerce' ) }{ ' ' }
 					{ organizationName }
 				</p>
 			) }
 
 			{ adsId && adsName && (
 				<p>
-					{ __( 'Ads Account:', 'snapchat-for-woo' ) } { adsName } (
+					{ __( 'Ads Account:', 'snapchat-for-woocommerce' ) } { adsName } (
 					{ adsId })
 				</p>
 			) }
 
 			{ pixelId && (
 				<p>
-					{ __( 'Pixel ID:', 'snapchat-for-woo' ) } { pixelId }
+					{ __( 'Pixel ID:', 'snapchat-for-woocommerce' ) } { pixelId }
 				</p>
 			) }
 		</div>

--- a/js/src/components/snapchat-account-card/account-details.js
+++ b/js/src/components/snapchat-account-card/account-details.js
@@ -28,14 +28,15 @@ const AccountDetails = () => {
 
 			{ adsId && adsName && (
 				<p>
-					{ __( 'Ads Account:', 'snapchat-for-woocommerce' ) } { adsName } (
-					{ adsId })
+					{ __( 'Ads Account:', 'snapchat-for-woocommerce' ) }{ ' ' }
+					{ adsName } ({ adsId })
 				</p>
 			) }
 
 			{ pixelId && (
 				<p>
-					{ __( 'Pixel ID:', 'snapchat-for-woocommerce' ) } { pixelId }
+					{ __( 'Pixel ID:', 'snapchat-for-woocommerce' ) }{ ' ' }
+					{ pixelId }
 				</p>
 			) }
 		</div>

--- a/js/src/components/snapchat-account-card/connect-snapchat-account-card.js
+++ b/js/src/components/snapchat-account-card/connect-snapchat-account-card.js
@@ -58,7 +58,7 @@ const ConnectSnapchatAccountCard = ( {
 				'error',
 				__(
 					'Unable to connect your Snapchat account. Please try again later.',
-					'snapchat-for-woo'
+					'snapchat-for-woocommerce'
 				)
 			);
 		}
@@ -69,7 +69,7 @@ const ConnectSnapchatAccountCard = ( {
 			return (
 				<AppButton
 					loading
-					text={ __( 'Connecting…', 'snapchat-for-woo' ) }
+					text={ __( 'Connecting…', 'snapchat-for-woocommerce' ) }
 				/>
 			);
 		}
@@ -83,7 +83,7 @@ const ConnectSnapchatAccountCard = ( {
 				eventProps={ { context: nextPageName } }
 				onClick={ handleConnectClick }
 			>
-				{ __( 'Connect', 'snapchat-for-woo' ) }
+				{ __( 'Connect', 'snapchat-for-woocommerce' ) }
 			</AppButton>
 		);
 	};
@@ -94,7 +94,7 @@ const ConnectSnapchatAccountCard = ( {
 			disabled={ disabled }
 			description={ __(
 				'Connect your Snapchat Business Account to sync your catalog and run Dynamic Ads.',
-				'snapchat-for-woo'
+				'snapchat-for-woocommerce'
 			) }
 			indicator={ getIndicator() }
 		/>

--- a/js/src/components/snapchat-account-card/constants.js
+++ b/js/src/components/snapchat-account-card/constants.js
@@ -5,5 +5,5 @@ import { __ } from '@wordpress/i18n';
 
 export const SNAPCHAT_DESCRIPTION = __(
 	'Connect your Snapchat Business Account to sync your catalog and run Dynamic Ads.',
-	'snapchat-for-woo'
+	'snapchat-for-woocommerce'
 );

--- a/js/src/components/snapchat-account-card/switch-account-button.js
+++ b/js/src/components/snapchat-account-card/switch-account-button.js
@@ -25,7 +25,7 @@ import useSwitchSnapchatAccount from '~/hooks/useSwitchSnapchatAccount';
 const SwitchAccountButton = ( {
 	text = __(
 		'Or, connect to a different Snapchat account',
-		'snapchat-for-woo'
+		'snapchat-for-woocommerce'
 	),
 	...restProps
 } ) => {

--- a/js/src/components/wpcom-account-card/connect-wpcom-account-card.js
+++ b/js/src/components/wpcom-account-card/connect-wpcom-account-card.js
@@ -45,7 +45,7 @@ const ConnectWPComAccountCard = () => {
 				'error',
 				__(
 					'Unable to connect your WordPress.com account. Please try again later.',
-					'snapchat-for-woo'
+					'snapchat-for-woocommerce'
 				)
 			);
 		}
@@ -56,7 +56,7 @@ const ConnectWPComAccountCard = () => {
 			appearance={ APPEARANCE.WPCOM }
 			description={ __(
 				'Required to connect with Snapchat',
-				'snapchat-for-woo'
+				'snapchat-for-woocommerce'
 			) }
 			indicator={
 				<AppButton
@@ -66,7 +66,7 @@ const ConnectWPComAccountCard = () => {
 					eventProps={ { context: nextPageName } }
 					onClick={ handleConnectClick }
 				>
-					{ __( 'Connect', 'snapchat-for-woo' ) }
+					{ __( 'Connect', 'snapchat-for-woocommerce' ) }
 				</AppButton>
 			}
 		/>

--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -67,7 +67,7 @@ export function receiveSetup( setup ) {
 /**
  * Creates an action to receive the settings data from the API.
  *
- * @param {Object} settings - Settings object, e.g., { trackConversions: boolean, triggerExport: boolean }.
+ * @param {Object} settings - Settings object, e.g., { capiEnabled: boolean, triggerExport: boolean }.
  * @return {Object} Action object.
  */
 export function receiveSettings( settings ) {
@@ -91,38 +91,9 @@ export function receiveSnapchatAccountDetails( snapchatAccountDetails ) {
 }
 
 /**
- * Update the conversions tracking status.
- *
- * @param {boolean} status The status of the conversions tracking.
- * @return {Object} Action object to update the conversions tracking status.
- */
-export async function updateTrackConversionsStatus( status ) {
-	try {
-		await apiFetch( {
-			path: `${ API_NAMESPACE }/snapchat/settings`,
-			method: 'POST',
-			data: {
-				capi_enabled: status,
-			},
-		} );
-
-		return receiveTrackConversionsStatus( status );
-	} catch ( error ) {
-		handleApiError(
-			error,
-			__(
-				'There was an error updating the conversions tracking status.',
-				'snapchat-for-woo'
-			)
-		);
-		throw error;
-	}
-}
-
-/**
  * Updates one or more settings on the server.
  *
- * @param {Object} updatedSettings - Partial settings to update, e.g. { trackConversions: true }.
+ * @param {Object} updatedSettings - Partial settings to update, e.g. { capiEnabled: true }.
  * @return {Function} Action object to update settings locally.
  */
 export async function updateSettings( updatedSettings ) {
@@ -132,12 +103,14 @@ export async function updateSettings( updatedSettings ) {
 			method: 'POST',
 			data: {
 				// Convert settings keys to match REST keys
-				capi_enabled: updatedSettings.trackConversions,
+				capi_enabled: updatedSettings.capiEnabled,
+				collect_pii: updatedSettings.collectPii,
 			},
 		} );
 
 		return receiveSettings( {
-			trackConversions: Boolean( response.capi_enabled ),
+			capiEnabled: Boolean( response.capi_enabled ),
+			collectPii: Boolean( response.collect_pii ),
 		} );
 	} catch ( error ) {
 		handleApiError(

--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -117,7 +117,7 @@ export async function updateSettings( updatedSettings ) {
 			error,
 			__(
 				'There was an error updating the settings.',
-				'snapchat-for-woo'
+				'snapchat-for-woocommerce'
 			)
 		);
 		throw error;
@@ -142,7 +142,7 @@ export async function fetchSnapchatAccount() {
 			error,
 			__(
 				'There was an error loading Snapchat account info.',
-				'snapchat-for-woo'
+				'snapchat-for-woocommerce'
 			)
 		);
 	}
@@ -166,7 +166,7 @@ export async function fetchSetup() {
 			error,
 			__(
 				'There was an error loading Snapchat setup.',
-				'snapchat-for-woo'
+				'snapchat-for-woocommerce'
 			)
 		);
 	}
@@ -196,7 +196,7 @@ export async function disconnectSnapchatAccount(
 			error,
 			__(
 				'Unable to disconnect your Snapchat account.',
-				'snapchat-for-woo'
+				'snapchat-for-woocommerce'
 			)
 		);
 		throw error;

--- a/js/src/data/index.js
+++ b/js/src/data/index.js
@@ -31,9 +31,9 @@ const store = createReduxStore( STORE_KEY, {
 			snapchat: null,
 		},
 		snapchat: null,
-		trackConversions: null,
 		settings: {
-			trackConversions: false,
+			capiEnabled: false,
+			collectPii: true,
 			triggerExport: false,
 			lastExportTimeStamp: '',
 			exportFileUrl: '',

--- a/js/src/data/reducer.js
+++ b/js/src/data/reducer.js
@@ -115,12 +115,6 @@ const reducer = ( state, action ) => {
 			return setIn( state, 'snapchat', snapchatAccountDetails );
 		}
 
-		case TYPES.RECEIVE_TRACK_CONVERSIONS_STATUS: {
-			const { status } = action;
-
-			return setIn( state, 'trackConversions', status );
-		}
-
 		case TYPES.DISCONNECT_ACCOUNTS_SNAPCHAT: {
 			return setIn( state, 'accounts.snapchat', null );
 		}

--- a/js/src/data/resolvers.js
+++ b/js/src/data/resolvers.js
@@ -92,7 +92,8 @@ export function getSettings() {
 
 			dispatch(
 				receiveSettings( {
-					trackConversions: Boolean( response.capi_enabled ),
+					capiEnabled: Boolean( response.capi_enabled ),
+					collectPii: Boolean( response.collect_pii ),
 					triggerExport: Boolean( response.trigger_export ),
 					lastExportTimeStamp: response.last_export_timestamp,
 					exportFileUrl: response.export_file_url,

--- a/js/src/data/resolvers.js
+++ b/js/src/data/resolvers.js
@@ -38,7 +38,7 @@ export function getJetpackAccount() {
 				error,
 				__(
 					'There was an error loading Jetpack account info.',
-					'snapchat-for-woo'
+					'snapchat-for-woocommerce'
 				)
 			);
 		}
@@ -71,7 +71,7 @@ export function getSnapchatAccountDetails() {
 				error,
 				__(
 					'There was an error loading Snapchat account details info.',
-					'snapchat-for-woo'
+					'snapchat-for-woocommerce'
 				)
 			);
 		}
@@ -104,7 +104,7 @@ export function getSettings() {
 				error,
 				__(
 					'There was an error fetching settings.',
-					'snapchat-for-woo'
+					'snapchat-for-woocommerce'
 				)
 			);
 		}

--- a/js/src/data/selectors.js
+++ b/js/src/data/selectors.js
@@ -84,7 +84,7 @@ export const getSnapchatAccountDetails = ( state ) => {
  * Retrieves the settings state.
  *
  * @param {Object} state - The Redux state.
- * @return {{ trackConversions: boolean, triggerExport: boolean, lastExportTimeStamp: string, exportFileUrl: string }} The settings object.
+ * @return {{ capiEnabled: boolean, triggerExport: boolean, lastExportTimeStamp: string, exportFileUrl: string }} The settings object.
  */
 export const getSettings = ( state ) => {
 	return state.settings;

--- a/js/src/hooks/useApiFetchCallback.js
+++ b/js/src/hooks/useApiFetchCallback.js
@@ -104,7 +104,7 @@ const shouldReturnResponseBody = ( options ) => {
  * 		>
  * 			{ __(
  * 				'Switch to my new URL',
- * 				'snapchat-for-woo'
+ * 				'snapchat-for-woocommerce'
  * 			) }
  * 		</AppButton>
  * )

--- a/js/src/hooks/useSettings.js
+++ b/js/src/hooks/useSettings.js
@@ -27,7 +27,8 @@ const useSettings = () => {
 		const settings = selector[ selectorName ]();
 
 		return {
-			isCapiEnabled: settings.trackConversions,
+			capiEnabled: settings.capiEnabled,
+			collectPii: settings.collectPii,
 			shouldTriggerExport: settings.triggerExport,
 			lastExportTimeStamp: settings.lastExportTimeStamp,
 			exportFileUrl: settings.exportFileUrl,

--- a/js/src/hooks/useSwitchSnapchatAccount.js
+++ b/js/src/hooks/useSwitchSnapchatAccount.js
@@ -37,7 +37,7 @@ const useSwitchSnapchatAccount = () => {
 			'info',
 			__(
 				'Connecting to a different Snapchat account, please wait…',
-				'snapchat-for-woo'
+				'snapchat-for-woocommerce'
 			)
 		);
 
@@ -54,7 +54,7 @@ const useSwitchSnapchatAccount = () => {
 				'error',
 				__(
 					'Unable to connect to a different Snapchat account. Please try again later.',
-					'snapchat-for-woo'
+					'snapchat-for-woocommerce'
 				)
 			);
 		} finally {

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -32,7 +32,7 @@ export const pagePaths = new Set();
 
 const woocommerceTranslation =
 	getSetting( 'admin' )?.woocommerceTranslation ||
-	__( 'WooCommerce', 'snapchat-for-woo' );
+	__( 'WooCommerce', 'snapchat-for-woocommerce' );
 
 // Refer to https://github.com/woocommerce/woocommerce/blob/9.7.1/plugins/woocommerce/client/admin/client/layout/controller.js#L82
 const PAGES_FILTER = 'woocommerce_admin_pages_list';
@@ -45,8 +45,8 @@ const registerPluginAdminPages = () => {
 	addFilter( PAGES_FILTER, namespace, ( pages ) => {
 		const initialBreadcrumbs = [
 			[ '', woocommerceTranslation ],
-			[ '/marketing', __( 'Marketing', 'snapchat-for-woo' ) ],
-			__( 'Snapchat for WooCommerce', 'snapchat-for-woo' ),
+			[ '/marketing', __( 'Marketing', 'snapchat-for-woocommerce' ) ],
+			__( 'Snapchat for WooCommerce', 'snapchat-for-woocommerce' ),
 		];
 
 		const pluginAdminPages = [
@@ -59,7 +59,7 @@ const registerPluginAdminPages = () => {
 			{
 				breadcrumbs: [
 					...initialBreadcrumbs,
-					__( 'Setup Snapchat', 'snapchat-for-woo' ),
+					__( 'Setup Snapchat', 'snapchat-for-woocommerce' ),
 				],
 				container: Onboarding,
 				path: '/snapchat/setup',
@@ -67,7 +67,7 @@ const registerPluginAdminPages = () => {
 			{
 				breadcrumbs: [
 					...initialBreadcrumbs,
-					__( 'Settings', 'snapchat-for-woo' ),
+					__( 'Settings', 'snapchat-for-woocommerce' ),
 				],
 				container: Settings,
 				path: '/snapchat/settings',

--- a/js/src/pages/onboarding/setup-stepper/saved-setup-stepper.js
+++ b/js/src/pages/onboarding/setup-stepper/saved-setup-stepper.js
@@ -46,7 +46,10 @@ const SavedSetupStepper = ( { savedStep } ) => {
 			steps={ [
 				{
 					key: STEP_NAME_KEY_MAP.accounts,
-					label: __( 'Set up your accounts', 'snapchat-for-woocommerce' ),
+					label: __(
+						'Set up your accounts',
+						'snapchat-for-woocommerce'
+					),
 					content: (
 						<SetupAccounts
 							onContinue={ handleSetupAccountsContinue }

--- a/js/src/pages/onboarding/setup-stepper/saved-setup-stepper.js
+++ b/js/src/pages/onboarding/setup-stepper/saved-setup-stepper.js
@@ -46,7 +46,7 @@ const SavedSetupStepper = ( { savedStep } ) => {
 			steps={ [
 				{
 					key: STEP_NAME_KEY_MAP.accounts,
-					label: __( 'Set up your accounts', 'snapchat-for-woo' ),
+					label: __( 'Set up your accounts', 'snapchat-for-woocommerce' ),
 					content: (
 						<SetupAccounts
 							onContinue={ handleSetupAccountsContinue }

--- a/js/src/pages/onboarding/setup-stepper/setup-accounts/index.js
+++ b/js/src/pages/onboarding/setup-stepper/setup-accounts/index.js
@@ -52,18 +52,18 @@ const SetupAccounts = ( props ) => {
 	return (
 		<StepContent>
 			<StepContentHeader
-				title={ __( 'Set up your accounts', 'snapchat-for-woo' ) }
+				title={ __( 'Set up your accounts', 'snapchat-for-woocommerce' ) }
 				description={ __(
 					'Connect the accounts required to use Snapchat integration.',
-					'snapchat-for-woo'
+					'snapchat-for-woocommerce'
 				) }
 			/>
 			<Section
 				className="sfw-wp-snapchat-accounts-section"
-				title={ __( 'Connect accounts', 'snapchat-for-woo' ) }
+				title={ __( 'Connect accounts', 'snapchat-for-woocommerce' ) }
 				description={ __(
 					'The following accounts are required to use the Snapchat plugin.',
-					'snapchat-for-woo'
+					'snapchat-for-woocommerce'
 				) }
 			>
 				<WPComAccountCard jetpack={ jetpack } />
@@ -76,7 +76,7 @@ const SetupAccounts = ( props ) => {
 						isPrimary
 						disabled={ isContinueButtonDisabled }
 						loading={ isSubmitting }
-						text={ __( 'Continue', 'snapchat-for-woo' ) }
+						text={ __( 'Continue', 'snapchat-for-woocommerce' ) }
 						onClick={ handleOnClick }
 					/>
 				</StepContentActions>

--- a/js/src/pages/onboarding/setup-stepper/setup-accounts/index.js
+++ b/js/src/pages/onboarding/setup-stepper/setup-accounts/index.js
@@ -52,7 +52,10 @@ const SetupAccounts = ( props ) => {
 	return (
 		<StepContent>
 			<StepContentHeader
-				title={ __( 'Set up your accounts', 'snapchat-for-woocommerce' ) }
+				title={ __(
+					'Set up your accounts',
+					'snapchat-for-woocommerce'
+				) }
 				description={ __(
 					'Connect the accounts required to use Snapchat integration.',
 					'snapchat-for-woocommerce'

--- a/js/src/pages/onboarding/setup-top-bar.js
+++ b/js/src/pages/onboarding/setup-top-bar.js
@@ -15,7 +15,7 @@ const SetupTopBar = () => {
 
 	return (
 		<TopBar
-			title={ __( 'Get started with Snapchat', 'snapchat-for-woo' ) }
+			title={ __( 'Get started with Snapchat', 'snapchat-for-woocommerce' ) }
 			helpButton={ <HelpIconButton eventContext="setup-snapchat" /> }
 			backHref={ adminUrl }
 		/>

--- a/js/src/pages/onboarding/setup-top-bar.js
+++ b/js/src/pages/onboarding/setup-top-bar.js
@@ -15,7 +15,10 @@ const SetupTopBar = () => {
 
 	return (
 		<TopBar
-			title={ __( 'Get started with Snapchat', 'snapchat-for-woocommerce' ) }
+			title={ __(
+				'Get started with Snapchat',
+				'snapchat-for-woocommerce'
+			) }
 			helpButton={ <HelpIconButton eventContext="setup-snapchat" /> }
 			backHref={ adminUrl }
 		/>

--- a/js/src/pages/settings/conversions-api/index.js
+++ b/js/src/pages/settings/conversions-api/index.js
@@ -47,7 +47,7 @@ const ConversionsAPI = () => {
 				'success',
 				__(
 					'Conversions API Tracking status updated successfully.',
-					'snapchat-for-woo'
+					'snapchat-for-woocommerce'
 				)
 			);
 		} catch ( error ) {
@@ -66,7 +66,7 @@ const ConversionsAPI = () => {
 				'success',
 				__(
 					'Collect PII status updated successfully.',
-					'snapchat-for-woo'
+					'snapchat-for-woocommerce'
 				)
 			);
 		} catch ( error ) {
@@ -83,10 +83,10 @@ const ConversionsAPI = () => {
 	return (
 		<AccountCard
 			className="sfw-settings-track-conversions"
-			title={ __( 'Conversions API', 'snapchat-for-woo' ) }
+			title={ __( 'Conversions API', 'snapchat-for-woocommerce' ) }
 			description={ __(
 				'Send server-side conversion events to improve attribution.',
-				'snapchat-for-woo'
+				'snapchat-for-woocommerce'
 			) }
 			actions={
 				<div className="sfw-settings-track-conversions__actions">
@@ -94,7 +94,7 @@ const ConversionsAPI = () => {
 						<CheckboxControl
 							label={ __(
 								'Enable Conversions API tracking',
-								'snapchat-for-woo'
+								'snapchat-for-woocommerce'
 							) }
 							checked={ capiEnabled }
 							disabled={ isSaving }
@@ -106,14 +106,14 @@ const ConversionsAPI = () => {
 						<CheckboxControl
 							label={ __(
 								'Collect Customer PII',
-								'snapchat-for-woo'
+								'snapchat-for-woocommerce'
 							) }
 							checked={ collectPii }
 							disabled={ isSaving }
 							onChange={ handleOnChangeOfCollectPii }
 							help={ __(
 								'Share additional customer data to help ads measure results more effectively.',
-								'snapchat-for-woo'
+								'snapchat-for-woocommerce'
 							) }
 						/>
 					</p>

--- a/js/src/pages/settings/conversions-api/index.js
+++ b/js/src/pages/settings/conversions-api/index.js
@@ -66,7 +66,7 @@ const ConversionsAPI = () => {
 				'success',
 				__(
 					'Collect PII status updated successfully.',
-					'snapchat-for-woocommerce'
+					'snapchat-for-woo'
 				)
 			);
 		} catch ( error ) {
@@ -106,12 +106,15 @@ const ConversionsAPI = () => {
 						<CheckboxControl
 							label={ __(
 								'Collect Customer PII',
-								'snapchat-for-woocommerce'
+								'snapchat-for-woo'
 							) }
 							checked={ collectPii }
 							disabled={ isSaving }
 							onChange={ handleOnChangeOfCollectPii }
-							help={ __( 'Share additional customer data to help ads measure results more effectively.', 'snapchat-for-woocommerce' ) }
+							help={ __(
+								'Share additional customer data to help ads measure results more effectively.',
+								'snapchat-for-woo'
+							) }
 						/>
 					</p>
 				</div>

--- a/js/src/pages/settings/conversions-api/index.js
+++ b/js/src/pages/settings/conversions-api/index.js
@@ -25,16 +25,20 @@ import './index.scss';
  * @return {JSX.Element} The rendered ConversionsAPI settings card.
  */
 const ConversionsAPI = () => {
-	const { isCapiEnabled, hasFinishedResolution } = useSettings();
+	const { capiEnabled, collectPii, hasFinishedResolution } = useSettings();
 	const [ isSaving, setIsSaving ] = useState( false );
 	const { createNotice } = useDispatchCoreNotices();
 	const { updateSettings } = useAppDispatch();
 
 	const toggleTrackConversions = useCallback( async () => {
-		await updateSettings( { trackConversions: ! isCapiEnabled } );
-	}, [ updateSettings, isCapiEnabled ] );
+		await updateSettings( { capiEnabled: ! capiEnabled } );
+	}, [ updateSettings, capiEnabled ] );
 
-	const handleOnChange = async () => {
+	const toggleCollectPii = useCallback( async () => {
+		await updateSettings( { collectPii: ! collectPii } );
+	}, [ updateSettings, collectPii ] );
+
+	const handleOnChangeOfConversionTracking = async () => {
 		try {
 			setIsSaving( true );
 			await toggleTrackConversions();
@@ -44,6 +48,25 @@ const ConversionsAPI = () => {
 				__(
 					'Conversions API Tracking status updated successfully.',
 					'snapchat-for-woo'
+				)
+			);
+		} catch ( error ) {
+			// Silently fail because the error is handled within `updateSettings` action.
+		} finally {
+			setIsSaving( false );
+		}
+	};
+
+	const handleOnChangeOfCollectPii = async () => {
+		try {
+			setIsSaving( true );
+			await toggleCollectPii();
+
+			createNotice(
+				'success',
+				__(
+					'Collect PII status updated successfully.',
+					'snapchat-for-woocommerce'
 				)
 			);
 		} catch ( error ) {
@@ -67,15 +90,30 @@ const ConversionsAPI = () => {
 			) }
 			actions={
 				<div className="sfw-settings-track-conversions__actions">
-					<CheckboxControl
-						label={ __(
-							'Enable Conversions API tracking',
-							'snapchat-for-woo'
-						) }
-						checked={ isCapiEnabled }
-						disabled={ isSaving }
-						onChange={ handleOnChange }
-					/>
+					<p>
+						<CheckboxControl
+							label={ __(
+								'Enable Conversions API tracking',
+								'snapchat-for-woo'
+							) }
+							checked={ capiEnabled }
+							disabled={ isSaving }
+							onChange={ handleOnChangeOfConversionTracking }
+						/>
+					</p>
+
+					<p>
+						<CheckboxControl
+							label={ __(
+								'Collect Customer PII',
+								'snapchat-for-woocommerce'
+							) }
+							checked={ collectPii }
+							disabled={ isSaving }
+							onChange={ handleOnChangeOfCollectPii }
+							help={ __( 'Share additional customer data to help ads measure results more effectively.', 'snapchat-for-woocommerce' ) }
+						/>
+					</p>
 				</div>
 			}
 		/>

--- a/js/src/pages/settings/disconnect-modal/confirm-modal.js
+++ b/js/src/pages/settings/disconnect-modal/confirm-modal.js
@@ -17,7 +17,10 @@ import { ALL_ACCOUNTS, SNAPCHAT_ACCOUNT } from './constants';
 const textDict = {
 	[ ALL_ACCOUNTS ]: {
 		title: __( 'Disconnect all accounts', 'snapchat-for-woocommerce' ),
-		confirmButton: __( 'Disconnect all accounts', 'snapchat-for-woocommerce' ),
+		confirmButton: __(
+			'Disconnect all accounts',
+			'snapchat-for-woocommerce'
+		),
 		confirmation: __(
 			'Yes, I want to disconnect all my accounts.',
 			'snapchat-for-woocommerce'
@@ -36,7 +39,10 @@ const textDict = {
 	},
 	[ SNAPCHAT_ACCOUNT ]: {
 		title: __( 'Disconnect Snapchat account', 'snapchat-for-woocommerce' ),
-		confirmButton: __( 'Disconnect Snapchat Account', 'snapchat-for-woocommerce' ),
+		confirmButton: __(
+			'Disconnect Snapchat Account',
+			'snapchat-for-woocommerce'
+		),
 		confirmation: __(
 			'Yes, I want to disconnect my Snapchat account.',
 			'snapchat-for-woocommerce'

--- a/js/src/pages/settings/disconnect-modal/confirm-modal.js
+++ b/js/src/pages/settings/disconnect-modal/confirm-modal.js
@@ -16,39 +16,39 @@ import { ALL_ACCOUNTS, SNAPCHAT_ACCOUNT } from './constants';
 
 const textDict = {
 	[ ALL_ACCOUNTS ]: {
-		title: __( 'Disconnect all accounts', 'snapchat-for-woo' ),
-		confirmButton: __( 'Disconnect all accounts', 'snapchat-for-woo' ),
+		title: __( 'Disconnect all accounts', 'snapchat-for-woocommerce' ),
+		confirmButton: __( 'Disconnect all accounts', 'snapchat-for-woocommerce' ),
 		confirmation: __(
 			'Yes, I want to disconnect all my accounts.',
-			'snapchat-for-woo'
+			'snapchat-for-woocommerce'
 		),
 		contents: [
 			__(
 				'I understand that I am disconnecting any WordPress.com account and Snapchat account connected to this extension.',
-				'snapchat-for-woo'
+				'snapchat-for-woocommerce'
 			),
-			__( 'Lorem ipsum', 'snapchat-for-woo' ),
+			__( 'Lorem ipsum', 'snapchat-for-woocommerce' ),
 			__(
 				'Dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
-				'snapchat-for-woo'
+				'snapchat-for-woocommerce'
 			),
 		],
 	},
 	[ SNAPCHAT_ACCOUNT ]: {
-		title: __( 'Disconnect Snapchat account', 'snapchat-for-woo' ),
-		confirmButton: __( 'Disconnect Snapchat Account', 'snapchat-for-woo' ),
+		title: __( 'Disconnect Snapchat account', 'snapchat-for-woocommerce' ),
+		confirmButton: __( 'Disconnect Snapchat Account', 'snapchat-for-woocommerce' ),
 		confirmation: __(
 			'Yes, I want to disconnect my Snapchat account.',
-			'snapchat-for-woo'
+			'snapchat-for-woocommerce'
 		),
 		contents: [
 			__(
 				'I understand that I am disconnecting my Snapchat account from this WooCommerce extension.',
-				'snapchat-for-woo'
+				'snapchat-for-woocommerce'
 			),
 			__(
 				'Some configurations for Snapchat created through WooCommerce may be lost. This cannot be undone.',
-				'snapchat-for-woo'
+				'snapchat-for-woocommerce'
 			),
 		],
 	},
@@ -112,7 +112,7 @@ export default function ConfirmModal( {
 					disabled={ isDisconnecting }
 					onClick={ handleRequestClose }
 				>
-					{ __( 'Never mind', 'snapchat-for-woo' ) }
+					{ __( 'Never mind', 'snapchat-for-woocommerce' ) }
 				</AppButton>,
 				<AppButton
 					key="2"

--- a/js/src/pages/settings/index.js
+++ b/js/src/pages/settings/index.js
@@ -37,7 +37,9 @@ const Settings = () => {
 		<div className="sfw-settings">
 			{ isOnboardingSuccessModalOpen && <OnboardingSuccessModal /> }
 
-			<Section title={ __( 'Product Catalog', 'snapchat-for-woocommerce' ) }>
+			<Section
+				title={ __( 'Product Catalog', 'snapchat-for-woocommerce' ) }
+			>
 				<ProductCatalog />
 			</Section>
 
@@ -52,7 +54,10 @@ const Settings = () => {
 			</Section>
 
 			<Section
-				title={ __( 'Manage Snapchat Connection', 'snapchat-for-woocommerce' ) }
+				title={ __(
+					'Manage Snapchat Connection',
+					'snapchat-for-woocommerce'
+				) }
 				description={ __(
 					'See your currently connected account or disconnect.',
 					'snapchat-for-woocommerce'

--- a/js/src/pages/settings/index.js
+++ b/js/src/pages/settings/index.js
@@ -37,25 +37,25 @@ const Settings = () => {
 		<div className="sfw-settings">
 			{ isOnboardingSuccessModalOpen && <OnboardingSuccessModal /> }
 
-			<Section title={ __( 'Product Catalog', 'snapchat-for-woo' ) }>
+			<Section title={ __( 'Product Catalog', 'snapchat-for-woocommerce' ) }>
 				<ProductCatalog />
 			</Section>
 
 			<Section
-				title={ __( 'Track Conversions', 'snapchat-for-woo' ) }
+				title={ __( 'Track Conversions', 'snapchat-for-woocommerce' ) }
 				description={ __(
 					'Manage how conversions are tracked on your site.',
-					'snapchat-for-woo'
+					'snapchat-for-woocommerce'
 				) }
 			>
 				<ConversionsAPI />
 			</Section>
 
 			<Section
-				title={ __( 'Manage Snapchat Connection', 'snapchat-for-woo' ) }
+				title={ __( 'Manage Snapchat Connection', 'snapchat-for-woocommerce' ) }
 				description={ __(
 					'See your currently connected account or disconnect.',
-					'snapchat-for-woo'
+					'snapchat-for-woocommerce'
 				) }
 			>
 				<LinkedAccounts />

--- a/js/src/pages/settings/linked-accounts.js
+++ b/js/src/pages/settings/linked-accounts.js
@@ -60,7 +60,7 @@ export default function LinkedAccounts() {
 						>
 							{ __(
 								'Disconnect Snapchat account',
-								'snapchat-for-woo'
+								'snapchat-for-woocommerce'
 							) }
 						</AppButton>
 					</Section.Card.Footer>

--- a/js/src/pages/settings/product-catalog/index.js
+++ b/js/src/pages/settings/product-catalog/index.js
@@ -95,20 +95,20 @@ const ProductCatalog = () => {
 		if ( exportInProgress ) {
 			return __(
 				'We’re generating your CSV file… This may take a few seconds.',
-				'snapchat-for-woo'
+				'snapchat-for-woocommerce'
 			);
 		}
 
 		if ( ! lastExported ) {
 			return __(
 				'Your product catalog is not synced to Snapchat yet. Generate a CSV to manually upload.',
-				'snapchat-for-woo'
+				'snapchat-for-woocommerce'
 			);
 		}
 
 		return sprintf(
 			// translators: %s: The date and time when the product catalog was last exported.
-			__( 'Last exported on %s.', 'snapchat-for-woo' ),
+			__( 'Last exported on %s.', 'snapchat-for-woocommerce' ),
 			lastExported
 		);
 	};
@@ -122,7 +122,7 @@ const ProductCatalog = () => {
 						onClick={ handleOnGenerateCsvClick }
 						loading={ exportInProgress }
 					>
-						{ __( 'Regenerate CSV', 'snapchat-for-woo' ) }
+						{ __( 'Regenerate CSV', 'snapchat-for-woocommerce' ) }
 					</AppButton>
 				</Flex>
 			);
@@ -134,7 +134,7 @@ const ProductCatalog = () => {
 				onClick={ handleOnGenerateCsvClick }
 				loading={ exportInProgress }
 			>
-				{ __( 'Generate CSV', 'snapchat-for-woo' ) }
+				{ __( 'Generate CSV', 'snapchat-for-woocommerce' ) }
 			</AppButton>
 		);
 	};
@@ -174,7 +174,7 @@ const ProductCatalog = () => {
 		<>
 			<AccountCard
 				className="sfw-product-catalog"
-				title={ __( 'Export Product Catalog', 'snapchat-for-woo' ) }
+				title={ __( 'Export Product Catalog', 'snapchat-for-woocommerce' ) }
 				description={ getDescription() }
 				indicator={ getIndicator() }
 			>
@@ -183,7 +183,7 @@ const ProductCatalog = () => {
 						<p>
 							{ __(
 								'The CSV file may have been deleted and could not be found. Click "Generate CSV" to regenerate a new one.',
-								'snapchat-for-woo'
+								'snapchat-for-woocommerce'
 							) }
 						</p>
 					</div>

--- a/js/src/pages/settings/product-catalog/index.js
+++ b/js/src/pages/settings/product-catalog/index.js
@@ -174,7 +174,10 @@ const ProductCatalog = () => {
 		<>
 			<AccountCard
 				className="sfw-product-catalog"
-				title={ __( 'Export Product Catalog', 'snapchat-for-woocommerce' ) }
+				title={ __(
+					'Export Product Catalog',
+					'snapchat-for-woocommerce'
+				) }
 				description={ getDescription() }
 				indicator={ getIndicator() }
 			>

--- a/js/src/pages/settings/product-catalog/useProductCatalogExport.js
+++ b/js/src/pages/settings/product-catalog/useProductCatalogExport.js
@@ -52,7 +52,7 @@ const useProductCatalogExport = (
 					'error',
 					__(
 						'No products found. Please create products to generate the CSV.',
-						'snapchat-for-woo'
+						'snapchat-for-woocommerce'
 					)
 				);
 				return;
@@ -60,7 +60,7 @@ const useProductCatalogExport = (
 
 			createNotice(
 				'error',
-				__( 'An error occurred', 'snapchat-for-woo' )
+				__( 'An error occurred', 'snapchat-for-woocommerce' )
 			);
 			onGenerateCsvError();
 		} catch ( error ) {
@@ -68,7 +68,7 @@ const useProductCatalogExport = (
 				'error',
 				sprintf(
 					// translators: %s: The error message returned from the CSV generation process.
-					__( 'CSV generation failed: %s', 'snapchat-for-woo' ),
+					__( 'CSV generation failed: %s', 'snapchat-for-woocommerce' ),
 					error.message
 				)
 			);

--- a/js/src/pages/settings/product-catalog/useProductCatalogExport.js
+++ b/js/src/pages/settings/product-catalog/useProductCatalogExport.js
@@ -68,7 +68,10 @@ const useProductCatalogExport = (
 				'error',
 				sprintf(
 					// translators: %s: The error message returned from the CSV generation process.
-					__( 'CSV generation failed: %s', 'snapchat-for-woocommerce' ),
+					__(
+						'CSV generation failed: %s',
+						'snapchat-for-woocommerce'
+					),
 					error.message
 				)
 			);

--- a/js/src/utils/getConnectedJetpackInfo.js
+++ b/js/src/utils/getConnectedJetpackInfo.js
@@ -25,5 +25,8 @@ export default function getConnectedJetpackInfo( jetpack ) {
 	}
 
 	// Show a connected text instead of owner email to non jetpack owner users.
-	return __( 'Successfully connected through Jetpack', 'snapchat-for-woocommerce' );
+	return __(
+		'Successfully connected through Jetpack',
+		'snapchat-for-woocommerce'
+	);
 }

--- a/js/src/utils/getConnectedJetpackInfo.js
+++ b/js/src/utils/getConnectedJetpackInfo.js
@@ -25,5 +25,5 @@ export default function getConnectedJetpackInfo( jetpack ) {
 	}
 
 	// Show a connected text instead of owner email to non jetpack owner users.
-	return __( 'Successfully connected through Jetpack', 'snapchat-for-woo' );
+	return __( 'Successfully connected through Jetpack', 'snapchat-for-woocommerce' );
 }

--- a/js/src/utils/handleError.js
+++ b/js/src/utils/handleError.js
@@ -41,7 +41,9 @@ export function resolveErrorMessage( error, leadingMessage, fallbackMessage ) {
 	}
 
 	if ( messages.length === 0 ) {
-		messages.push( __( 'Unknown error occurred.', 'snapchat-for-woocommerce' ) );
+		messages.push(
+			__( 'Unknown error occurred.', 'snapchat-for-woocommerce' )
+		);
 	}
 
 	return messages.join(

--- a/js/src/utils/handleError.js
+++ b/js/src/utils/handleError.js
@@ -41,14 +41,14 @@ export function resolveErrorMessage( error, leadingMessage, fallbackMessage ) {
 	}
 
 	if ( messages.length === 0 ) {
-		messages.push( __( 'Unknown error occurred.', 'snapchat-for-woo' ) );
+		messages.push( __( 'Unknown error occurred.', 'snapchat-for-woocommerce' ) );
 	}
 
 	return messages.join(
 		_x(
 			' ',
 			`The spacing between sentences. It's a space in English. Please use an empty string if no spacing is needed in that language.`,
-			'snapchat-for-woo'
+			'snapchat-for-woocommerce'
 		)
 	);
 }


### PR DESCRIPTION
Closes: https://linear.app/a8c/issue/SNAPWOO-54/enhancing-conversion-data-with-pii

### Description:
- Implements settings to collect PII, which is enabled by default (92d2c28, 875439e, 4e044eb)
- Collects: phone number, email, fname, lname, city, country and postal/zip code
- All values are hashed using SHA256
- Improves error logging messages
- Fixes incorrect text domain

### Screenshot
<img width="1065" height="257" alt="Screenshot 2025-09-12 at 4 27 00 PM" src="https://github.com/user-attachments/assets/039b1431-57d9-4d06-bb7d-6b4522a2ba24" />

### Testing
- Verify payloads using logs
- The PII data should only be collected if the setting is enabled
- If Consent framework is present on the site, then PII should only be collected if **Collect Customer PII** is enabled, _AND_ the customer explicitly consents for Marketing cookies.