### PR TITLE
SNAPWOO-59: Add IP Address to Pixel payload

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,4 @@
+***Snapchat for WooCommerce Changelog ***
+
+2025-09-26 - version 0.1.0
+* Initial release

--- a/includes/Admin/Export/Writer/CsvExportWriter.php
+++ b/includes/Admin/Export/Writer/CsvExportWriter.php
@@ -148,10 +148,10 @@ class CsvExportWriter implements ExportWriterInterface {
 		$fp = fopen( 'php://temp', 'r+' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
 
 		if ( $is_empty ) {
-			fputcsv( $fp, array_keys( $decoded_row ) );
+			fputcsv( $fp, array_keys( $decoded_row ), ',', '"', '\\' );
 		}
 
-		fputcsv( $fp, array_values( $decoded_row ) );
+		fputcsv( $fp, array_values( $decoded_row ), ',', '"', '\\' );
 		rewind( $fp );
 
 		$new_data = stream_get_contents( $fp );

--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -16,6 +16,7 @@ use SnapchatForWooCommerce\Utils\AssetLoader;
 use SnapchatForWooCommerce\Utils\Helper;
 use SnapchatForWooCommerce\Tracking\PixelTrackingService;
 use SnapchatForWooCommerce\Tracking\ConversionTrackingService;
+use SnapchatForWooCommerce\Utils\UserIdentifier;
 
 /**
  * Manages frontend asset loading for plugin features.
@@ -104,6 +105,7 @@ class Assets {
 					'is_conversion_enabled' => ConversionTrackingService::is_enabled(),
 					'capi_nonce'            => wp_create_nonce( 'capi_nonce' ),
 					'prefix'                => Helper::with_prefix( '' ),
+					'user_ip'               => UserIdentifier::add_ip_address(),
 				)
 			)
 		);

--- a/includes/Tracking/ConversionEventLogger.php
+++ b/includes/Tracking/ConversionEventLogger.php
@@ -53,11 +53,11 @@ class ConversionEventLogger {
 	 * @since 0.1.0
 	 *
 	 * @param string $event_name  Event identifier (e.g. 'PURCHASE', 'ADD_CART').
-	 * @param int    $status_code HTTP status code returned from the API.
+	 * @param ?int    $status_code HTTP status code returned from the API.
 	 * @param array  $context     Optional structured context.
 	 * @return void
 	 */
-	public function log_event( string $event_name, int $status_code, array $context = array() ): void {
+	public function log_event( string $event_name, ?int $status_code, array $context = array() ): void {
 		$is_success = $status_code >= 200 && $status_code < 300;
 
 		$message = sprintf(

--- a/includes/Tracking/ConversionEventLogger.php
+++ b/includes/Tracking/ConversionEventLogger.php
@@ -53,7 +53,7 @@ class ConversionEventLogger {
 	 * @since 0.1.0
 	 *
 	 * @param string $event_name  Event identifier (e.g. 'PURCHASE', 'ADD_CART').
-	 * @param ?int    $status_code HTTP status code returned from the API.
+	 * @param ?int   $status_code HTTP status code returned from the API.
 	 * @param array  $context     Optional structured context.
 	 * @return void
 	 */

--- a/includes/Tracking/ConversionTrackingService.php
+++ b/includes/Tracking/ConversionTrackingService.php
@@ -172,9 +172,8 @@ class ConversionTrackingService implements ServiceStatusInterface {
 	public function handle_async_add_to_cart(): void {
 		check_ajax_referer( 'capi_nonce', 'security' );
 
-		$raw_input  = filter_input( INPUT_POST, 'payload', FILTER_UNSAFE_RAW );
-		$raw_input  = wp_unslash( $raw_input );
-		$data       = json_decode( $raw_input, true );
+		$payload    = wp_unslash( $_POST['payload'] ?? '{}' );
+		$data       = json_decode( $payload, true );
 		$product_id = absint( $data['product_id'] ?? 0 );
 		$quantity   = absint( $data['quantity'] ?? 0 );
 		$event_id   = sanitize_text_field( $data['event_id'] ?? '' );
@@ -196,9 +195,8 @@ class ConversionTrackingService implements ServiceStatusInterface {
 	public function handle_async_view_content(): void {
 		check_ajax_referer( 'capi_nonce', 'security' );
 
-		$raw_input  = filter_input( INPUT_POST, 'payload', FILTER_UNSAFE_RAW );
-		$raw_input  = wp_unslash( $raw_input );
-		$data       = json_decode( $raw_input, true );
+		$payload    = wp_unslash( $_POST['payload'] ?? '{}' );
+		$data       = json_decode( $payload, true );
 		$product_id = isset( $data['item_ids'][0] ) ? absint( $data['item_ids'][0] ) : 0;
 		$event_id   = isset( $data['event_id'] ) ? sanitize_text_field( $data['event_id'] ) : '';
 
@@ -218,9 +216,8 @@ class ConversionTrackingService implements ServiceStatusInterface {
 	public function handle_async_start_checkout(): void {
 		check_ajax_referer( 'capi_nonce', 'security' );
 
-		$raw_input = filter_input( INPUT_POST, 'payload', FILTER_UNSAFE_RAW );
-		$raw_input = wp_unslash( $raw_input );
-		$data      = json_decode( $raw_input, true );
+		$payload    = wp_unslash( $_POST['payload'] ?? '{}' );
+		$data      = json_decode( $payload, true );
 		$event_id  = isset( $data['event_id'] ) ? sanitize_text_field( $data['event_id'] ) : '';
 		$cart      = WC() ? WC()->cart : null;
 
@@ -245,9 +242,8 @@ class ConversionTrackingService implements ServiceStatusInterface {
 	public function handle_async_page_view(): void {
 		check_ajax_referer( 'capi_nonce', 'security' );
 
-		$raw_input = filter_input( INPUT_POST, 'payload', FILTER_UNSAFE_RAW );
-		$raw_input = wp_unslash( $raw_input );
-		$data      = json_decode( $raw_input, true );
+		$payload    = wp_unslash( $_POST['payload'] ?? '{}' );
+		$data      = json_decode( $payload, true );
 		$event_id  = isset( $data['event_id'] ) ? sanitize_text_field( $data['event_id'] ) : '';
 
 		$this->tracker->track_page_view( $event_id );

--- a/includes/Tracking/ConversionTrackingService.php
+++ b/includes/Tracking/ConversionTrackingService.php
@@ -216,10 +216,10 @@ class ConversionTrackingService implements ServiceStatusInterface {
 	public function handle_async_start_checkout(): void {
 		check_ajax_referer( 'capi_nonce', 'security' );
 
-		$payload    = wp_unslash( $_POST['payload'] ?? '{}' );
-		$data      = json_decode( $payload, true );
-		$event_id  = isset( $data['event_id'] ) ? sanitize_text_field( $data['event_id'] ) : '';
-		$cart      = WC() ? WC()->cart : null;
+		$payload  = wp_unslash( $_POST['payload'] ?? '{}' );
+		$data     = json_decode( $payload, true );
+		$event_id = isset( $data['event_id'] ) ? sanitize_text_field( $data['event_id'] ) : '';
+		$cart     = WC() ? WC()->cart : null;
 
 		$this->tracker->track_start_checkout( $cart, $event_id );
 	}
@@ -242,9 +242,9 @@ class ConversionTrackingService implements ServiceStatusInterface {
 	public function handle_async_page_view(): void {
 		check_ajax_referer( 'capi_nonce', 'security' );
 
-		$payload    = wp_unslash( $_POST['payload'] ?? '{}' );
-		$data      = json_decode( $payload, true );
-		$event_id  = isset( $data['event_id'] ) ? sanitize_text_field( $data['event_id'] ) : '';
+		$payload  = wp_unslash( $_POST['payload'] ?? '{}' );
+		$data     = json_decode( $payload, true );
+		$event_id = isset( $data['event_id'] ) ? sanitize_text_field( $data['event_id'] ) : '';
 
 		$this->tracker->track_page_view( $event_id );
 	}

--- a/includes/Tracking/RemotePixelTracker.php
+++ b/includes/Tracking/RemotePixelTracker.php
@@ -252,6 +252,7 @@ final class RemotePixelTracker implements PixelTrackerInterface {
 			'item_category'  => implode( ', ', array_unique( $item_categories ) ),
 			'number_items'   => $number_items,
 			'integration'    => 'woocommerce-v1',
+			'ip_address'     => UserIdentifier::add_ip_address(),
 		);
 
 		if ( Storage\Helper::is_collect_pii_enabled() ) {

--- a/includes/Utils/Storage/OptionDefaults.php
+++ b/includes/Utils/Storage/OptionDefaults.php
@@ -223,7 +223,7 @@ final class OptionDefaults {
 			self::ORGANIZATION_NAME       => '',
 			self::PIXEL_ENABLED           => 'yes',
 			self::PIXEL_ID                => '',
-			self::CONVERSIONS_ENABLED     => 'no',
+			self::CONVERSIONS_ENABLED     => 'yes',
 			self::CONVERSION_ACCESS_TOKEN => '',
 			self::COLLECT_PII             => 'yes',
 			self::CATALOG_ID              => '',

--- a/includes/Utils/UserIdentifier.php
+++ b/includes/Utils/UserIdentifier.php
@@ -119,7 +119,7 @@ final class UserIdentifier {
 	 * @since 0.1.0
 	 *
 	 * @param array<string,mixed>|null $data Optional. Reference to the user_data array.
-	 * @return void
+	 * @return ?string
 	 */
 	public static function add_ip_address( ?array &$data = null ): ?string {
 		$ip = '';

--- a/includes/Utils/UserIdentifier.php
+++ b/includes/Utils/UserIdentifier.php
@@ -118,10 +118,10 @@ final class UserIdentifier {
 	 *
 	 * @since 0.1.0
 	 *
-	 * @param array<string,mixed> $data Reference to the user_data array.
+	 * @param array<string,mixed>|null $data Optional. Reference to the user_data array.
 	 * @return void
 	 */
-	private static function add_ip_address( array &$data ): void {
+	public static function add_ip_address( ?array &$data = null ): ?string {
 		$ip = '';
 
 		if ( isset( $_SERVER['HTTP_CF_CONNECTING_IP'] ) ) {
@@ -135,8 +135,15 @@ final class UserIdentifier {
 		}
 
 		if ( $ip ) {
-			$data['client_ip_address'] = $ip;
+			if ( is_array( $data ) ) {
+				$data['client_ip_address'] = $ip;
+				return null;
+			}
+
+			return $ip;
 		}
+
+		return null;
 	}
 
 	/**

--- a/js/src/pages/settings/conversions-api/index.js
+++ b/js/src/pages/settings/conversions-api/index.js
@@ -112,7 +112,7 @@ const ConversionsAPI = () => {
 							disabled={ isSaving }
 							onChange={ handleOnChangeOfCollectPii }
 							help={ __(
-								'Share additional customer data to help ads measure results more effectively.',
+								'Share additional customer data (PII) with both Pixel and Conversions API events to improve ads measurement.',
 								'snapchat-for-woocommerce'
 							) }
 						/>

--- a/js/src/tracking/pixel/utils.js
+++ b/js/src/tracking/pixel/utils.js
@@ -21,6 +21,7 @@ export const sendPixelEvent = ( eventName, eventParams ) => {
 	window.snaptr( 'track', eventName, {
 		...eventParams,
 		integration: 'woocommerce-v1',
+		ip_address: TRACKING_DATA_VAR.user_ip,
 	} );
 };
 

--- a/tests/e2e/specs/settings.spec.js
+++ b/tests/e2e/specs/settings.spec.js
@@ -99,7 +99,7 @@ test.describe( 'Snapchat Settings', () => {
 		settingPage.goto();
 
 		await locator.getCapiCheckbox().click();
-		await expect( locator.getCapiCheckbox() ).toBeEnabled();
+		await expect( locator.getCapiCheckbox() ).toBeDisabled();
 		await expect(
 			page
 				.getByText(
@@ -109,7 +109,7 @@ test.describe( 'Snapchat Settings', () => {
 		).toBeVisible();
 
 		await locator.getCapiCheckbox().click();
-		await expect( locator.getCapiCheckbox() ).toBeDisabled();
+		await expect( locator.getCapiCheckbox() ).toBeEnabled();
 		await expect(
 			page
 				.getByText(


### PR DESCRIPTION
Closes: https://linear.app/a8c/issue/SNAPWOO-59/snapchat-feedback-changes

### Description
- Sends IP Address with the Pixel event payload
- Enables conversion tracking by default
- Improves Collect PII setting description