### PR TITLE
Ignore false positives from QIT

### DIFF
--- a/includes/Tracking/ConversionTrackingService.php
+++ b/includes/Tracking/ConversionTrackingService.php
@@ -172,7 +172,7 @@ class ConversionTrackingService implements ServiceStatusInterface {
 	public function handle_async_add_to_cart(): void {
 		check_ajax_referer( 'capi_nonce', 'security' );
 
-		$payload    = wp_unslash( $_POST['payload'] ?? '{}' );
+		$payload    = wp_unslash( $_POST['payload'] ?? '{}' ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$data       = json_decode( $payload, true );
 		$product_id = absint( $data['product_id'] ?? 0 );
 		$quantity   = absint( $data['quantity'] ?? 0 );
@@ -195,7 +195,7 @@ class ConversionTrackingService implements ServiceStatusInterface {
 	public function handle_async_view_content(): void {
 		check_ajax_referer( 'capi_nonce', 'security' );
 
-		$payload    = wp_unslash( $_POST['payload'] ?? '{}' );
+		$payload    = wp_unslash( $_POST['payload'] ?? '{}' ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$data       = json_decode( $payload, true );
 		$product_id = isset( $data['item_ids'][0] ) ? absint( $data['item_ids'][0] ) : 0;
 		$event_id   = isset( $data['event_id'] ) ? sanitize_text_field( $data['event_id'] ) : '';
@@ -216,7 +216,7 @@ class ConversionTrackingService implements ServiceStatusInterface {
 	public function handle_async_start_checkout(): void {
 		check_ajax_referer( 'capi_nonce', 'security' );
 
-		$payload  = wp_unslash( $_POST['payload'] ?? '{}' );
+		$payload  = wp_unslash( $_POST['payload'] ?? '{}' ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$data     = json_decode( $payload, true );
 		$event_id = isset( $data['event_id'] ) ? sanitize_text_field( $data['event_id'] ) : '';
 		$cart     = WC() ? WC()->cart : null;
@@ -242,7 +242,7 @@ class ConversionTrackingService implements ServiceStatusInterface {
 	public function handle_async_page_view(): void {
 		check_ajax_referer( 'capi_nonce', 'security' );
 
-		$payload  = wp_unslash( $_POST['payload'] ?? '{}' );
+		$payload  = wp_unslash( $_POST['payload'] ?? '{}' ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$data     = json_decode( $payload, true );
 		$event_id = isset( $data['event_id'] ) ? sanitize_text_field( $data['event_id'] ) : '';
 

--- a/includes/Utils/AssetLoader.php
+++ b/includes/Utils/AssetLoader.php
@@ -38,6 +38,7 @@ class AssetLoader {
 		$script_asset_path = $script_path . '.asset.php';
 
 		if ( file_exists( $script_asset_path ) ) {
+			// phpcs:ignore Squiz.Commenting.InlineComment.InvalidEndChar
 			$asset_data = require $script_asset_path; // nosemgrep
 		} else {
 			$asset_data = array(
@@ -69,6 +70,7 @@ class AssetLoader {
 		$style_asset_path = $style_path . '.asset.php';
 
 		if ( file_exists( $style_asset_path ) ) {
+			// phpcs:ignore Squiz.Commenting.InlineComment.InvalidEndChar
 			$asset_data = require $style_asset_path; // nosemgrep
 		} else {
 			$asset_data = array(

--- a/includes/Utils/AssetLoader.php
+++ b/includes/Utils/AssetLoader.php
@@ -38,7 +38,7 @@ class AssetLoader {
 		$script_asset_path = $script_path . '.asset.php';
 
 		if ( file_exists( $script_asset_path ) ) {
-			$asset_data = require $script_asset_path;
+			$asset_data = require $script_asset_path; // nosemgrep
 		} else {
 			$asset_data = array(
 				'dependencies' => array(),
@@ -69,7 +69,7 @@ class AssetLoader {
 		$style_asset_path = $style_path . '.asset.php';
 
 		if ( file_exists( $style_asset_path ) ) {
-			$asset_data = require $style_asset_path;
+			$asset_data = require $style_asset_path; // nosemgrep
 		} else {
 			$asset_data = array(
 				'dependencies' => array(),


### PR DESCRIPTION
Slack ref: https://fueled.slack.com/archives/C01TYRCJ1QD/p1758889238964409?thread_ts=1758883650.890419&cid=C01TYRCJ1QD

Adds comments to ignore false positives.

# Note
The E2E tests aren't failing, they are in fact failing to start. We're facing the same on Reddit as well, unsure why. Needs more investigation.