### PR TITLE
SNAPWOO-61: Ensure PHP 8.4 Compatibility

### DIFF
--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -7,10 +7,14 @@ on:
       - develop
     paths:
       - "**.php"
+      - composer.json # Required for phpcompat sniffs.
+      - composer.lock # Required for phpcompat sniffs.
       - .github/workflows/php-coding-standards.yml
   pull_request:
     paths:
       - "**.php"
+      - composer.json # Required for phpcompat sniffs.
+      - composer.lock # Required for phpcompat sniffs.
       - .github/workflows/php-coding-standards.yml
 
 concurrency:

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -55,15 +55,24 @@ jobs:
           node-version-file: ".nvmrc"
           ignore-scripts: "no"
 
+      # The use of WP-Scripts results in PHP files being generated during the npm build step.
+      # In order to ensure PHP Compatibility, the build step must be run in order to ensure all
+      # files in the production release of the plugin are compatible with the target PHP versions.
       - name: Build production bundle
         run: |
           echo "::group::Build log"
           npm run build
           echo "::endgroup::"
 
+      # The PHP Compatibility sniffs need to include the vendor directory to ensure all files
+      # in the production release of the plugin are compatible with the target PHP versions.
       - name: Install composer production dependencies
         run: composer install --no-dev --prefer-dist --optimize-autoloader
 
+      # Installed globally to ensure dev dependencies are not included in compatibility sniffs.
+      # At the time of writing no production version of PHPCompatibility/PHP-Compatibility supports
+      # PHP 8.4 so a dev version is used in order to ensure the sniffs that have been created are
+      # included in the checks.
       - name: Install PHP Compatibility dev-develop globally
         run: |
           composer global config --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer true

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -47,6 +47,7 @@ jobs:
         uses: woocommerce/grow/prepare-php@da5279aa4d76745ef32970e49b5ef7903a3b457a # v2.2.2
         with:
           tools: cs2pr
+          install-deps: no
 
       - name: Install composer production dependencies
         run: composer install --no-dev --prefer-dist --optimize-autoloader

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -36,3 +36,23 @@ jobs:
       - name: Run PHPCS on all files
         run: vendor/bin/phpcs ./* -q --report=checkstyle | cs2pr
 
+  phpcompat:
+    name: PHP compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Prepare PHP
+        uses: woocommerce/grow/prepare-php@da5279aa4d76745ef32970e49b5ef7903a3b457a # v2.2.2
+        with:
+          tools: cs2pr
+
+      - name: Install composer production dependencies
+        run: composer install --no-dev --prefer-dist --optimize-autoloader
+
+      - name: Install PHP Compatibility dev-develop globally
+        run: composer global require --dev phpcompatibility/php-compatibility:dev-develop
+
+      - name: Run PHPCompatibility on all files
+        run: ~/.composer/vendor/bin/phpcs . --standard=.php-compat.xml.dist --runtime-set testVersion 5.6-8.3 -q --report=checkstyle | cs2pr

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install PHP Compatibility dev-develop globally
         run: |
           composer global config --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
-          composer global require --dev phpcompatibility/php-compatibility:dev-develop
+          composer global require --dev phpcompatibility/php-compatibility:dev-develop#8daeec54772a592ad369be23ae02ed593c71e7f1
 
       - name: Run PHPCompatibility on all files
         run: ~/.composer/vendor/bin/phpcs . --standard=.php-compat.xml.dist -q --report=checkstyle | cs2pr

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -52,7 +52,9 @@ jobs:
         run: composer install --no-dev --prefer-dist --optimize-autoloader
 
       - name: Install PHP Compatibility dev-develop globally
-        run: composer global require --dev phpcompatibility/php-compatibility:dev-develop
+        run: |
+          composer global config --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
+          composer global require --dev phpcompatibility/php-compatibility:dev-develop
 
       - name: Run PHPCompatibility on all files
         run: ~/.composer/vendor/bin/phpcs . --standard=.php-compat.xml.dist --runtime-set testVersion 5.6-8.3 -q --report=checkstyle | cs2pr

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -49,6 +49,18 @@ jobs:
           tools: cs2pr
           install-deps: no
 
+      - name: Prepare node
+        uses: woocommerce/grow/prepare-node@da5279aa4d76745ef32970e49b5ef7903a3b457a # v2.2.2
+        with:
+          node-version-file: ".nvmrc"
+          ignore-scripts: "no"
+
+      - name: Build production bundle
+        run: |
+          echo "::group::Build log"
+          npm run build
+          echo "::endgroup::"
+
       - name: Install composer production dependencies
         run: composer install --no-dev --prefer-dist --optimize-autoloader
 

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -57,4 +57,4 @@ jobs:
           composer global require --dev phpcompatibility/php-compatibility:dev-develop
 
       - name: Run PHPCompatibility on all files
-        run: ~/.composer/vendor/bin/phpcs . --standard=.php-compat.xml.dist --runtime-set testVersion 5.6-8.3 -q --report=checkstyle | cs2pr
+        run: ~/.composer/vendor/bin/phpcs . --standard=.php-compat.xml.dist -q --report=checkstyle | cs2pr

--- a/.php-compat.xml.dist
+++ b/.php-compat.xml.dist
@@ -73,22 +73,4 @@
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.spl_autoload_functionsFound"/>
     </rule>
 
-    <!--
-    The ParagonieSodiumCompat ruleset includes the ParagonieRandomCompat ruleset.
-
-    RandomCompat is contained in /wp-includes/random_compat/ since WP 4.4.0 and removed in WP 6.3.0
-    SodiumCompat is contained in /wp-includes/sodium_compat/ since WP 5.2.0
-    -->
-    <rule ref="PHPCompatibilityParagonieSodiumCompat"/>
-
-    <!-- Whitelist the WP Core mysql_to_rfc3339() function. -->
-    <rule ref="PHPCompatibility.Extensions.RemovedExtensions">
-        <properties>
-            <!-- Contained in /wp-includes/functions.php. -->
-            <property name="functionWhitelist" type="array">
-                <element value="mysql_to_rfc3339"/>
-            </property>
-        </properties>
-    </rule>
-
 </ruleset>

--- a/.php-compat.xml.dist
+++ b/.php-compat.xml.dist
@@ -1,0 +1,94 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHPCompatibilityWP" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
+
+    <description>WordPress specific ruleset which checks for PHP cross version compatibility.</description>
+
+	<!-- Test PHP 7.4 upwards -->
+	<config name="testVersion" value="7.4-"/>
+	<file>.</file>
+	<arg name="extensions" value="php,inc" />
+
+    <!--
+    The WordPress minimum PHP requirement was 5.2.4 up to WP 5.1.
+    As of WP 5.2, the new minimum PHP requirement is PHP 5.6.20.
+    As of WP 6.3, the new minimum PHP requirement is PHP 7.0.0.
+    As of WP 6.6, the new minimum PHP requirement is PHP 7.2.24.
+    Add the following in your project PHP_CodeSniffer ruleset to enforce this:
+    <config name="testVersion" value="7.2-"/>
+
+    This directive is not included in this ruleset as individual projects may use
+    a different (higher) minimum PHP version.
+    -->
+
+    <rule ref="PHPCompatibility">
+        <!--
+        Contained in /wp-includes/compat.php.
+
+        History of the polyfills in WP:
+        * hash_hmac(): since WP 3.2.0.
+        * json_encode() and json_decode(): since unknown.
+        * hash_equals(): since WP 3.9.2.
+        * JSON_PRETTY_PRINT: since WP 4.1.0.
+        * json_last_error_msg(): since WP 4.4.0.
+        * JsonSerializable: since WP 4.4.0.
+        * array_replace_recursive(): since WP 4.5.3 up to 5.2.x. The polyfill was removed in WP 5.3.
+        * is_iterable(): since WP 4.9.6
+        * is_countable(): since WP 4.9.6
+        * IMAGETYPE_WEBP and IMG_WEBP: since WP 5.8.0.
+        * array_key_first(): since WP 5.9.0
+        * array_key_last(): since WP 5.9.0
+        * str_contains(): since WP 5.9.0
+        * str_starts_with(): since WP 5.9.0
+        * str_ends_with(): since WP 5.9.0
+        * array_is_list(): since WP 6.5.0
+        -->
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.hash_hmacFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.json_encodeFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.json_decodeFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.hash_equalsFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.json_pretty_printFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.json_last_error_msgFound"/>
+        <exclude name="PHPCompatibility.Interfaces.NewInterfaces.jsonserializableFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_replace_recursiveFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.is_iterableFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.is_countableFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.imagetype_webpFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.img_webpFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_key_firstFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_key_lastFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.str_containsFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.str_starts_withFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.str_ends_withFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_is_listFound"/>
+
+        <!--
+        Contained in /wp-includes/spl-autoload-compat.php.
+
+        History of the polyfills in WP:
+        * spl_autoload_register(), spl_autoload_unregister() and spl_autoload_functions() were
+          introduced in WP 4.6.0 and available up to WP 5.2.x. The polyfills were removed in WP 5.3.
+        -->
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.spl_autoload_registerFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.spl_autoload_unregisterFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.spl_autoload_functionsFound"/>
+    </rule>
+
+    <!--
+    The ParagonieSodiumCompat ruleset includes the ParagonieRandomCompat ruleset.
+
+    RandomCompat is contained in /wp-includes/random_compat/ since WP 4.4.0 and removed in WP 6.3.0
+    SodiumCompat is contained in /wp-includes/sodium_compat/ since WP 5.2.0
+    -->
+    <rule ref="PHPCompatibilityParagonieSodiumCompat"/>
+
+    <!-- Whitelist the WP Core mysql_to_rfc3339() function. -->
+    <rule ref="PHPCompatibility.Extensions.RemovedExtensions">
+        <properties>
+            <!-- Contained in /wp-includes/functions.php. -->
+            <property name="functionWhitelist" type="array">
+                <element value="mysql_to_rfc3339"/>
+            </property>
+        </properties>
+    </rule>
+
+</ruleset>

--- a/.php-compat.xml.dist
+++ b/.php-compat.xml.dist
@@ -4,8 +4,8 @@
     <description>WordPress specific ruleset which checks for PHP cross version compatibility.</description>
 	<!-- Once PHPCompatibility/PHPCompatibilityWP supports the targeted versions of PHP, this config file can be updated accordingly. -->
 
-	<!-- Test PHP 7.4 upwards -->
-	<config name="testVersion" value="7.4-"/>
+	<!-- Test PHP 7.4 thru 8.4 -->
+	<config name="testVersion" value="7.4-8.4"/>
 	<file>.</file>
 	<arg name="extensions" value="php,inc" />
 

--- a/.php-compat.xml.dist
+++ b/.php-compat.xml.dist
@@ -2,23 +2,12 @@
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHPCompatibilityWP" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
 
     <description>WordPress specific ruleset which checks for PHP cross version compatibility.</description>
+	<!-- Once PHPCompatibility/PHPCompatibilityWP supports the targeted versions of PHP, this config file can be updated accordingly. -->
 
 	<!-- Test PHP 7.4 upwards -->
 	<config name="testVersion" value="7.4-"/>
 	<file>.</file>
 	<arg name="extensions" value="php,inc" />
-
-    <!--
-    The WordPress minimum PHP requirement was 5.2.4 up to WP 5.1.
-    As of WP 5.2, the new minimum PHP requirement is PHP 5.6.20.
-    As of WP 6.3, the new minimum PHP requirement is PHP 7.0.0.
-    As of WP 6.6, the new minimum PHP requirement is PHP 7.2.24.
-    Add the following in your project PHP_CodeSniffer ruleset to enforce this:
-    <config name="testVersion" value="7.2-"/>
-
-    This directive is not included in this ruleset as individual projects may use
-    a different (higher) minimum PHP version.
-    -->
 
     <rule ref="PHPCompatibility">
         <!--

--- a/snapchat-for-woocommerce.php
+++ b/snapchat-for-woocommerce.php
@@ -9,6 +9,7 @@
  * Domain Path: /languages
  * Requires Plugins: woocommerce
  * Requires PHP: 7.4
+ * PHP tested up to: 8.4
  * Requires at least: 6.7
  * WC requires at least: 10.0
  * WC tested up to: 10.2

--- a/tests/Unit/Admin/Export/Service/ProductExportServiceTest.php
+++ b/tests/Unit/Admin/Export/Service/ProductExportServiceTest.php
@@ -150,7 +150,12 @@ class ProductExportServiceTest extends WP_UnitTestCase {
 
 		$this->assertFileExists( $file_path );
 
-		$csv = array_map( 'str_getcsv', file( $file_path ) );
+		$csv = array_map(
+			static function( $line ) {
+				return str_getcsv( $line, ',', '"', '\\' );
+			},
+			file( $file_path )
+		);
 
 		$this->assertEquals(
 			array( 'id', 'title', 'description', 'link', 'image_link', 'availability', 'price', 'gtin' ),

--- a/tests/Unit/Admin/Export/Writer/CsvExportWriterTest.php
+++ b/tests/Unit/Admin/Export/Writer/CsvExportWriterTest.php
@@ -59,8 +59,8 @@ class CsvExportWriterTest extends WP_UnitTestCase {
 		$this->writer->append_row( $file, $data );
 
 		$handle = fopen( $file, 'r' );
-		$header = fgetcsv( $handle );
-		$row    = fgetcsv( $handle );
+		$header = fgetcsv( $handle, null, ',', '"', '\\' );
+		$row    = fgetcsv( $handle, null, ',', '"', '\\' );
 		fclose( $handle );
 
 		$this->assertSame( array_keys( $data ), $header );


### PR DESCRIPTION
**PHP Compatibility sniffs**

This adds an action to run the PHP Compatibility sniffs to ensure PHP 8.4 support.

In order to ensure the production code supports PHP 8.4, the sniffs are intentionally run against the production dependencies in the vendor directory.

In order to achieve this there are a couple of oddities in the GitHub action:

* The PHPCompatibility sniffs are installed from the develop branch using the commit https://github.com/PHPCompatibility/PHPCompatibility/commit/8daeec54772a592ad369be23ae02ed593c71e7f1 -- the PHP 8.4 sniffs are incomplete so there isn't a stable version for PHP 8.4
* The PHPCompatibility sniffs are installed and run globally so the files are kept out of the plugin directory.
* Runs the node build step as the use of `wp-scripts` generates PHP files that need to be checked.
* Includes the full ruleset covering WP Polyfills as `PHPCompatibility/PHPCompatibilityWP` won't work with the dev version of the PHP compat ruleset.

**PHP Compatibility updates**


### Changelog entry
> Dev - Fixes warnings for the use of `fgetcsv()` in the test suite.

Fixes https://linear.app/a8c/issue/SNAPWOO-61/project-ensure-php-84-compatibility