### PR TITLE
SNAPWOO-60: Show an admin notice to uninstall the legacy Snapchat Pixel plugin if it is installed and active.

### DIFF
--- a/includes/Admin/Notices.php
+++ b/includes/Admin/Notices.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Displays admin notices for Snapchat for WooCommerce.
+ *
+ * This class is responsible for displaying admin notices for the plugin.
+ *
+ * @package SnapchatForWooCommerce\Admin
+ * @since x.x.x
+ */
+
+namespace SnapchatForWooCommerce\Admin;
+
+use SnapchatForWooCommerce\Utils\Helper;
+
+/**
+ * Handles admin notices for Snapchat for WooCommerce.
+ *
+ * Registers the `admin_notices` action to display admin notices for the plugin.
+ *
+ * @since x.x.x
+ */
+class Notices {
+
+	/**
+	 * Registers WordPress admin-side hooks.
+	 *
+	 * Hooks into `admin_notices` to display admin notices for the plugin.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return void
+	 */
+	public function register_hooks(): void {
+		add_action( 'admin_notices', array( $this, 'maybe_display_notice_about_legacy_snapchat_plugin' ) );
+	}
+
+	/**
+	 * Displays a notice for the uninstall the legacy Snapchat plugin.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return void
+	 */
+	public function maybe_display_notice_about_legacy_snapchat_plugin(): void {
+		if ( ! Helper::is_legacy_snapchat_plugin_active() ) {
+			return;
+		}
+
+		$notice_message = sprintf(
+			/* translators: %1$s and %2$s are placeholders for the link to the documentation. */
+			__( 'You currently have two Snapchat plugins installed. Having both plugins active can cause reporting issues. Please uninstall the \'Snapchat Pixel for WooCommerce\' (Legacy Plugin) by following the steps %1$shere%2$s.', 'snapchat-for-woocommerce' ),
+			'<a href="https://woocommerce.com/document/snapchat-for-woocommerce/#section-4" target="_blank" rel="noopener noreferrer">',
+			'</a>'
+		);
+
+		?>
+		<div class="notice notice-warning is-dismissible">
+			<p>
+				<?php
+				echo wp_kses(
+					$notice_message,
+					array(
+						'a' => array(
+							'href'   => true,
+							'target' => true,
+							'rel'    => true,
+						),
+					)
+				);
+				?>
+			</p>
+		</div>
+		<?php
+	}
+}

--- a/includes/Admin/Notices.php
+++ b/includes/Admin/Notices.php
@@ -42,7 +42,8 @@ class Notices {
 	 * @return void
 	 */
 	public function maybe_display_notice_about_legacy_snapchat_plugin(): void {
-		if ( ! Helper::is_legacy_snapchat_plugin_active() ) {
+		// Bail if the legacy Snapchat plugin is not active.
+		if ( ! ( is_plugin_active( 'snap-pixel-for-woocommerce/snapchat-pixel-for-woocommerce.php' ) || class_exists( 'snap_pixel' ) ) ) {
 			return;
 		}
 

--- a/includes/ServiceContainer.php
+++ b/includes/ServiceContainer.php
@@ -121,6 +121,7 @@ final class ServiceContainer {
 					new Admin\Menu(),
 					new Admin\Onboarding(),
 					new ProductMeta\ProductMetaFields(),
+					new Admin\Notices(),
 				);
 
 			default:

--- a/includes/Utils/Helper.php
+++ b/includes/Utils/Helper.php
@@ -213,4 +213,15 @@ class Helper {
 		// Return scalars (int, float, bool, null) as-is.
 		return $data;
 	}
+
+	/**
+	 * Checks if the legacy Snapchat plugin is active.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return bool True if the legacy Snapchat plugin is active, false otherwise.
+	 */
+	public static function is_legacy_snapchat_plugin_active() {
+		return is_plugin_active( 'snap-pixel-for-woocommerce/snapchat-pixel-for-woocommerce.php' ) || class_exists( 'snap_pixel' );
+	}
 }

--- a/includes/Utils/Helper.php
+++ b/includes/Utils/Helper.php
@@ -213,15 +213,4 @@ class Helper {
 		// Return scalars (int, float, bool, null) as-is.
 		return $data;
 	}
-
-	/**
-	 * Checks if the legacy Snapchat plugin is active.
-	 *
-	 * @since x.x.x
-	 *
-	 * @return bool True if the legacy Snapchat plugin is active, false otherwise.
-	 */
-	public static function is_legacy_snapchat_plugin_active() {
-		return is_plugin_active( 'snap-pixel-for-woocommerce/snapchat-pixel-for-woocommerce.php' ) || class_exists( 'snap_pixel' );
-	}
 }

--- a/tests/e2e/global-setup.js
+++ b/tests/e2e/global-setup.js
@@ -103,11 +103,16 @@ module.exports = async ( config ) => {
 		try {
 			console.log( 'Trying to log-in as customer...' );
 			await customerPage.goto( `/wp-admin` );
-			await customerPage.fill( 'input[name="log"]', customer.username );
-			await customerPage.fill( 'input[name="pwd"]', customer.password );
-			await customerPage.locator( '#wp-submit' ).click();
 			await customerPage.waitForLoadState( 'networkidle' );
-
+			await customerPage
+				.locator( 'input[name="log"]' )
+				.fill( customer.username );
+			await customerPage.waitForTimeout( 200 );
+			await customerPage
+				.locator( 'input[name="pwd"]' )
+				.fill( customer.password );
+			await customerPage.waitForTimeout( 200 );
+			await customerPage.locator( '#wp-submit' ).click();
 			await customerPage.goto( `/my-account` );
 			await expect(
 				customerPage.locator(


### PR DESCRIPTION
### Changes proposed in this Pull Request:
As requested in SNAPWOO-60, this PR adds an admin notice prompting users to uninstall the legacy Snapchat Pixel plugin if it is installed and active, to help prevent potential reporting issues.

<img width="2069" height="287" alt="image" src="https://github.com/user-attachments/assets/3b44763f-a4f4-4c5d-8dbd-0b2b38118654" />

Closes https://linear.app/a8c/issue/SNAPWOO-60/show-an-admin-notice-to-users-if-they-have-the-old-snapchat-pixel

### Steps to test the changes in this Pull Request:
1. Install and activate the legacy Snapchat plugin: https://wordpress.org/plugins/snap-pixel-for-woocommerce/
2. Verify that a dismissible warning notice appears, prompting you to uninstall the legacy Snapchat Pixel plugin.
3. Uninstall the legacy Snapchat plugin and confirm that the notice no longer appears.

### Changelog entry
> Add - Display an admin notice prompting users to uninstall the legacy Snapchat Pixel plugin if it is installed and active.