### PR TITLE
SNAPWOO-64: Fix signals deduplication issues

### DIFF
--- a/includes/Tracking/ConversionEvent/PurchaseEvent.php
+++ b/includes/Tracking/ConversionEvent/PurchaseEvent.php
@@ -96,7 +96,7 @@ final class PurchaseEvent extends EventPayloadBase implements ConversionEventInt
 		$default = array(
 			'event_name'       => self::ID,
 			'event_source_url' => $this->order->get_checkout_order_received_url(),
-			'event_id'         => EventIdRegistry::get_purchase_id( $this->order->get_id() ),
+			'event_id'         => EventIdRegistry::get_purchase_id(),
 			'user_data'        => array(),
 			'custom_data'      => array(
 				'content_ids' => array_filter( $ids, fn( $id ) => ! empty( $id ) ),

--- a/includes/Tracking/EventIdRegistry.php
+++ b/includes/Tracking/EventIdRegistry.php
@@ -22,18 +22,17 @@ namespace SnapchatForWooCommerce\Tracking;
 final class EventIdRegistry {
 
 	/**
-	 * Returns a order key for the given purchase.
-	 *
-	 * Uses the WooCommerce order ID as the key.
+	 * Returns a unique event ID for the purchase event.
 	 *
 	 * @since 0.1.0
 	 *
-	 * @param int $order_id The Order ID.
-	 *
-	 * @return string Order key.
+	 * @return string Unique event ID.
 	 */
-	public static function get_purchase_id( $order_id ): string {
-		$order = wc_get_order( $order_id );
-		return $order instanceof \WC_Order ? (string) $order->get_order_key() : '';
+	public static function get_purchase_id(): string {
+		static $purchase_event_id = null;
+		if ( null === $purchase_event_id ) {
+			$purchase_event_id = wp_generate_uuid4();
+		}
+		return $purchase_event_id;
 	}
 }

--- a/includes/Tracking/RemotePixelTracker.php
+++ b/includes/Tracking/RemotePixelTracker.php
@@ -243,16 +243,18 @@ final class RemotePixelTracker implements PixelTrackerInterface {
 			}
 		}
 
-		$payload = array(
-			'price'          => $total,
-			'currency'       => $currency,
-			'event_id'       => $order_key,
-			'transaction_id' => $order_key,
-			'item_ids'       => $item_ids,
-			'item_category'  => implode( ', ', array_unique( $item_categories ) ),
-			'number_items'   => $number_items,
-			'integration'    => 'woocommerce-v1',
-			'ip_address'     => UserIdentifier::add_ip_address(),
+		$event_id = EventIdRegistry::get_purchase_id();
+		$payload  = array(
+			'price'           => $total,
+			'currency'        => $currency,
+			'event_id'        => $event_id,
+			'client_dedup_id' => $event_id,
+			'transaction_id'  => $order_key,
+			'item_ids'        => $item_ids,
+			'item_category'   => implode( ', ', array_unique( $item_categories ) ),
+			'number_items'    => $number_items,
+			'integration'     => 'woocommerce-v1',
+			'ip_address'      => UserIdentifier::add_ip_address(),
 		);
 
 		if ( Storage\Helper::is_collect_pii_enabled() ) {

--- a/includes/Tracking/RemotePixelTracker.php
+++ b/includes/Tracking/RemotePixelTracker.php
@@ -216,7 +216,6 @@ final class RemotePixelTracker implements PixelTrackerInterface {
 		$order->update_meta_data( self::ORDER_PIXEL_TRACKED_META_KEY, 1 );
 		$order->save_meta_data();
 
-		$order_key       = $order->get_order_key();
 		$total           = $order->get_total();
 		$currency        = $order->get_currency();
 		$item_ids        = array();
@@ -249,7 +248,7 @@ final class RemotePixelTracker implements PixelTrackerInterface {
 			'currency'        => $currency,
 			'event_id'        => $event_id,
 			'client_dedup_id' => $event_id,
-			'transaction_id'  => $order_key,
+			'transaction_id'  => $order_id,
 			'item_ids'        => $item_ids,
 			'item_category'   => implode( ', ', array_unique( $item_categories ) ),
 			'number_items'    => $number_items,

--- a/tests/Unit/Tracking/EventIdRegistryTest.php
+++ b/tests/Unit/Tracking/EventIdRegistryTest.php
@@ -11,54 +11,62 @@ namespace SnapchatForWooCommerce\Tests\Unit\Tracking;
 
 use PHPUnit\Framework\TestCase;
 use SnapchatForWooCommerce\Tracking\EventIdRegistry;
-use WC_Helper_Order;
 
 /**
  * @covers \SnapchatForWooCommerce\Tracking\EventIdRegistry
  */
 final class EventIdRegistryTest extends TestCase {
-
-	/**
-	 * The ID of the order created during the test.
-	 *
-	 * @var int
-	 */
-	private $order_id;
-
 	/**
 	 * Sets up the test environment.
 	 */
 	public function setUp(): void {
 		parent::setUp();
-
-		// Create a simple product using WC helper.
-		$product = \WC_Helper_Product::create_simple_product();
-
-		// Create an order and add the product.
-		$order = wc_create_order();
-		$order->add_product( $product, 1 );
-		$order->calculate_totals();
-		$order->save();
-
-		$this->order_id = $order->get_id();
 	}
 
 	/**
-	 * Tests get_purchase_id() returns correct order key for a valid order.
+	 * Test that get_purchase_id returns a non-empty string.
+	 *
+	 * @since 0.1.0
 	 */
-	public function test_get_purchase_id_returns_order_key_for_valid_order(): void {
-		$order    = wc_get_order( $this->order_id );
-		$expected = $order->get_order_key();
-		$actual   = EventIdRegistry::get_purchase_id( $this->order_id );
+	public function test_get_purchase_id_returns_non_empty_string(): void {
+		$purchase_id = EventIdRegistry::get_purchase_id();
 
-		$this->assertSame( $expected, $actual );
+		$this->assertIsString( $purchase_id );
+		$this->assertNotEmpty( $purchase_id );
 	}
 
 	/**
-	 * Tests get_purchase_id() returns empty string for an invalid order ID.
+	 * Test that get_purchase_id returns the same ID on multiple calls.
+	 *
+	 * This tests the static caching behavior to ensure idempotency
+	 * within a single request lifecycle.
+	 *
+	 * @since x.x.x
 	 */
-	public function test_get_purchase_id_returns_empty_string_for_invalid_order(): void {
-		$actual = EventIdRegistry::get_purchase_id( 999999 ); // Assuming this ID doesn't exist.
-		$this->assertSame( '', $actual );
+	public function test_get_purchase_id_returns_same_id_on_multiple_calls(): void {
+		$first_call  = EventIdRegistry::get_purchase_id();
+		$second_call = EventIdRegistry::get_purchase_id();
+		$third_call  = EventIdRegistry::get_purchase_id();
+
+		$this->assertSame( $first_call, $second_call );
+		$this->assertSame( $second_call, $third_call );
+	}
+
+	/**
+	 * Test that get_purchase_id is consistent across the request.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_get_purchase_id_maintains_consistency(): void {
+		$ids = array();
+
+		// Call the method 10 times
+		for ( $i = 0; $i < 10; $i++ ) {
+			$ids[] = EventIdRegistry::get_purchase_id();
+		}
+
+		// All IDs should be identical
+		$unique_ids = array_unique( $ids );
+		$this->assertCount( 1, $unique_ids );
 	}
 }

--- a/tests/e2e/global-setup.js
+++ b/tests/e2e/global-setup.js
@@ -103,11 +103,16 @@ module.exports = async ( config ) => {
 		try {
 			console.log( 'Trying to log-in as customer...' );
 			await customerPage.goto( `/wp-admin` );
-			await customerPage.fill( 'input[name="log"]', customer.username );
-			await customerPage.fill( 'input[name="pwd"]', customer.password );
-			await customerPage.locator( '#wp-submit' ).click();
 			await customerPage.waitForLoadState( 'networkidle' );
-
+			await customerPage
+				.locator( 'input[name="log"]' )
+				.fill( customer.username );
+			await customerPage.waitForTimeout( 200 );
+			await customerPage
+				.locator( 'input[name="pwd"]' )
+				.fill( customer.password );
+			await customerPage.waitForTimeout( 200 );
+			await customerPage.locator( '#wp-submit' ).click();
 			await customerPage.goto( `/my-account` );
 			await expect(
 				customerPage.locator(

--- a/tests/e2e/specs/tracking/pixels/purchase-event.spec.js
+++ b/tests/e2e/specs/tracking/pixels/purchase-event.spec.js
@@ -21,7 +21,8 @@ import { customer as c } from '../../../config';
 let admin = null;
 let customer = null;
 let orderUrl = '';
-const uuid4Regex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const uuid4Regex =
+	/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 test.beforeAll( 'Setup contexts', async ( { browser } ) => {
 	admin = await browser.newPage( { storageState: process.env.ADMINSTATE } );
@@ -88,7 +89,7 @@ test.describe( 'PURCHASE event', () => {
 			expect( payload.price ).toBe( '40.00' );
 			expect( payload.currency ).toBe( 'USD' );
 			expect( payload.event_id ).toMatch( uuid4Regex );
-			expect( payload.transaction_id ).toBeGreaterThan(0);
+			expect( payload.transaction_id ).toBeGreaterThan( 0 );
 			expect( payload.item_ids ).toEqual( [ '10', '11' ] );
 			expect( payload.number_items ).toBe( 3 );
 			expect( payload ).toHaveProperty( 'item_category' );

--- a/tests/e2e/specs/tracking/pixels/purchase-event.spec.js
+++ b/tests/e2e/specs/tracking/pixels/purchase-event.spec.js
@@ -21,7 +21,7 @@ import { customer as c } from '../../../config';
 let admin = null;
 let customer = null;
 let orderUrl = '';
-const orderKeyRegex = /^wc_order_([a-zA-Z0-9]+)$/i;
+const uuid4Regex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 test.beforeAll( 'Setup contexts', async ( { browser } ) => {
 	admin = await browser.newPage( { storageState: process.env.ADMINSTATE } );
@@ -87,8 +87,8 @@ test.describe( 'PURCHASE event', () => {
 			expect( payload.integration ).toBe( 'woocommerce-v1' );
 			expect( payload.price ).toBe( '40.00' );
 			expect( payload.currency ).toBe( 'USD' );
-			expect( payload.event_id ).toMatch( orderKeyRegex );
-			expect( payload.transaction_id ).toMatch( orderKeyRegex );
+			expect( payload.event_id ).toMatch( uuid4Regex );
+			expect( payload.transaction_id ).toBeGreaterThan(0);
 			expect( payload.item_ids ).toEqual( [ '10', '11' ] );
 			expect( payload.number_items ).toBe( 3 );
 			expect( payload ).toHaveProperty( 'item_category' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:
This PR updates the event payload for Pixel and CAPI events. It primarily makes the following changes:

* Adds `client_dedup_id` to the Pixel purchase event payload.
* Updates the `transaction_id` value from the order key to the order ID in Pixel purchase event.
* Updates the `event_id` value of the CAPI event to match the Pixel’s `client_dedup_id` (previously, we were sending the order key in `event_id`, it is now updated to use `uuidv4` to align with the Pixel’s `client_dedup_id`).

Closes https://linear.app/a8c/issue/SNAPWOO-64/fix-signals-deduplication-issues

### Steps to test the changes in this Pull Request:

1. Install the **Snapchat Pixel Helper** Chrome extension in your Chrome browser.
2. Add a product to the cart and place an order. On the order thank-you page, check the Pixel Purchase event payload and validate the following:
   * The order ID is sent in `transaction_id`.
   * Copy the client deduplication ID and ensure it matches the `event_id` of the purchase CAPI event.

### Changelog entry
> Fix - Resolve signal deduplication issues.