### PR TITLE
SNAPWOO-70: Update integration value to include current plugin version. 

### DIFF
--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -106,6 +106,7 @@ class Assets {
 					'capi_nonce'            => wp_create_nonce( 'capi_nonce' ),
 					'prefix'                => Helper::with_prefix( '' ),
 					'user_ip'               => UserIdentifier::add_ip_address(),
+					'integration'           => Helper::get_integration_identifier(),
 				)
 			)
 		);

--- a/includes/Tracking/ConversionEvent/EventPayloadBase.php
+++ b/includes/Tracking/ConversionEvent/EventPayloadBase.php
@@ -27,13 +27,6 @@ use SnapchatForWooCommerce\Utils\Helper;
  */
 class EventPayloadBase {
 	/**
-	 * Identifier of this integration as recognized by the Ad Partner.
-	 *
-	 * @since 0.1.0
-	 */
-	public const INTEGRATION = 'woocommerce-v1';
-
-	/**
 	 * Source describing where the event was observed.
 	 * Common values include: WEB, APP, OFFLINE.
 	 *
@@ -51,7 +44,7 @@ class EventPayloadBase {
 	 *
 	 * The returned array includes:
 	 * - `event_time`       — Epoch timestamp (ms preferred) of when the event occurred.
-	 * - `integration`      — Identifier string for this integration (`woocommerce-v1`).
+	 * - `integration`      — Identifier string for this integration (eg: `woocommerce-v1-0-0`).
 	 * - `event_source_url` — The URL where the event originated (from {@see wc_get_raw_referer()}).
 	 * - `action_source`    — The source channel describing where the event was observed.
 	 *
@@ -62,7 +55,7 @@ class EventPayloadBase {
 	public function build_payload(): array {
 		return array(
 			'event_time'       => Helper::get_event_time(),
-			'integration'      => self::INTEGRATION,
+			'integration'      => Helper::get_integration_identifier(),
 			'event_source_url' => (string) wc_get_raw_referer(),
 			'action_source'    => self::ACTION_SOURCE,
 		);

--- a/includes/Tracking/RemotePixelTracker.php
+++ b/includes/Tracking/RemotePixelTracker.php
@@ -20,6 +20,7 @@ use SnapchatForWooCommerce\Utils\Storage;
 use SnapchatForWooCommerce\Tracking\Consent;
 use SnapchatForWooCommerce\Utils\UserIdentifier;
 use SnapchatForWooCommerce\Config;
+use SnapchatForWooCommerce\Utils\Helper;
 
 /**
  * Fetches and injects Snapchat pixel tracking code into WooCommerce frontend pages.
@@ -252,7 +253,7 @@ final class RemotePixelTracker implements PixelTrackerInterface {
 			'item_ids'        => $item_ids,
 			'item_category'   => implode( ', ', array_unique( $item_categories ) ),
 			'number_items'    => $number_items,
-			'integration'     => 'woocommerce-v1',
+			'integration'     => Helper::get_integration_identifier(),
 			'ip_address'      => UserIdentifier::add_ip_address(),
 		);
 

--- a/includes/Utils/Helper.php
+++ b/includes/Utils/Helper.php
@@ -222,4 +222,13 @@ class Helper {
 	public static function is_legacy_snapchat_plugin_active() {
 		return is_plugin_active( 'snap-pixel-for-woocommerce/snapchat-pixel-for-woocommerce.php' ) || class_exists( 'snap_pixel' );
 	}
+
+	/**
+	 * Returns the integration identifier to send in Pixel and CAPI event payload.
+	 *
+	 * @return string The integration identifier (eg: `woocommerce-v1-0-0`).
+	 */
+	public static function get_integration_identifier(): string {
+		return 'woocommerce-v' . str_replace( '.', '-', SNAPCHAT_FOR_WOOCOMMERCE_VERSION );
+	}
 }

--- a/js/src/tracking/pixel/utils.js
+++ b/js/src/tracking/pixel/utils.js
@@ -20,7 +20,7 @@ export const sendPixelEvent = ( eventName, eventParams ) => {
 
 	window.snaptr( 'track', eventName, {
 		...eventParams,
-		integration: 'woocommerce-v1',
+		integration: TRACKING_DATA_VAR.integration,
 		ip_address: TRACKING_DATA_VAR.user_ip,
 	} );
 };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "snapchat-for-woocommerce",
 	"title": "Snapchat for WooCommerce",
 	"description": "Snapchat for WooCommerce",
-	"version": "0.1.0",
+	"version": "1.0.2",
 	"author": "The WordPress Contributors",
 	"license": "GPL-3.0+",
 	"keywords": [

--- a/tests/e2e/config/index.js
+++ b/tests/e2e/config/index.js
@@ -1,11 +1,14 @@
+/**
+ * Internal dependencies
+ */
 import { version } from '../../../package.json';
 
-const admin = {
+export const admin = {
 	username: 'admin',
 	password: 'password',
 };
 
-const customer = {
+export const customer = {
 	username: 'customer',
 	password: 'password',
 	billing: {
@@ -25,8 +28,4 @@ const customer = {
 	},
 };
 
-module.exports = {
-	admin,
-	customer,
-	integration: `woocommerce-v${ version?.replaceAll( '.', '-' ) }`,
-};
+export const integration = `woocommerce-v${ version?.replaceAll( '.', '-' ) }`;

--- a/tests/e2e/config/index.js
+++ b/tests/e2e/config/index.js
@@ -1,3 +1,5 @@
+import { version } from '../../../package.json';
+
 const admin = {
 	username: 'admin',
 	password: 'password',
@@ -26,4 +28,5 @@ const customer = {
 module.exports = {
 	admin,
 	customer,
+	integration: `woocommerce-v${ version?.replaceAll( '.', '-' ) }`,
 };

--- a/tests/e2e/specs/tracking/pixels/add_cart-event.spec.js
+++ b/tests/e2e/specs/tracking/pixels/add_cart-event.spec.js
@@ -7,6 +7,7 @@ const { test, expect } = require( '@playwright/test' );
  * Internal dependencies
  */
 import { findSnaptrEvent, getThemes, switchTheme } from '../../../utils';
+import { integration } from '../../../config';
 
 const anyUuidRegex =
 	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -35,7 +36,7 @@ test.describe( 'ADD_CART event', () => {
 
 			const [ , , payload ] = ADD_CART;
 
-			expect( payload.integration ).toBe( 'woocommerce-v1' );
+			expect( payload.integration ).toBe( integration );
 			expect( payload.price ).toBe( 10 );
 			expect( payload.event_id ).toMatch( anyUuidRegex );
 			expect( payload.client_dedup_id ).toMatch( anyUuidRegex );

--- a/tests/e2e/specs/tracking/pixels/page_view-event.spec.js
+++ b/tests/e2e/specs/tracking/pixels/page_view-event.spec.js
@@ -7,6 +7,7 @@ const { test, expect } = require( '@playwright/test' );
  * Internal dependencies
  */
 import { findSnaptrEvent, getThemes, switchTheme } from '../../../utils';
+import { integration } from '../../../config';
 
 test.describe( 'PAGE_VIEW event', () => {
 	test.use( { storageState: process.env.ADMINSTATE } );
@@ -31,7 +32,7 @@ test.describe( 'PAGE_VIEW event', () => {
 				expect( PAGE_VIEW ).not.toBe( null );
 
 				const [ , , payload ] = PAGE_VIEW;
-				expect( payload.integration ).toBe( 'woocommerce-v1' );
+				expect( payload.integration ).toBe( integration );
 			} );
 		}
 

--- a/tests/e2e/specs/tracking/pixels/purchase-event.spec.js
+++ b/tests/e2e/specs/tracking/pixels/purchase-event.spec.js
@@ -16,7 +16,7 @@ import {
 	singleAddToCart,
 	clearCart,
 } from '../../../utils';
-import { customer as c } from '../../../config';
+import { customer as c, integration } from '../../../config';
 
 let admin = null;
 let customer = null;
@@ -85,7 +85,7 @@ test.describe( 'PURCHASE event', () => {
 			expect( PURCHASE ).not.toBe( null );
 
 			const [ , , payload ] = PURCHASE;
-			expect( payload.integration ).toBe( 'woocommerce-v1' );
+			expect( payload.integration ).toBe( integration );
 			expect( payload.price ).toBe( '40.00' );
 			expect( payload.currency ).toBe( 'USD' );
 			expect( payload.event_id ).toMatch( uuid4Regex );

--- a/tests/e2e/specs/tracking/pixels/start_checkout-event.spec.js
+++ b/tests/e2e/specs/tracking/pixels/start_checkout-event.spec.js
@@ -13,6 +13,7 @@ import {
 	singleAddToCart,
 	clearCart,
 } from '../../../utils';
+import { integration } from '../../../config';
 
 let admin = null;
 let customer = null;
@@ -24,7 +25,7 @@ async function checkoutAssertions( page ) {
 
 	const [ , , payload ] = START_CHECKOUT;
 
-	expect( payload.integration ).toBe( 'woocommerce-v1' );
+	expect( payload.integration ).toBe( integration );
 	expect( payload.price ).toBe( '40.00' );
 	expect( payload.currency ).toBe( 'USD' );
 	expect( payload.item_ids ).toEqual( [ '10', '11' ] );

--- a/tests/e2e/specs/tracking/pixels/view_content-event.spec.js
+++ b/tests/e2e/specs/tracking/pixels/view_content-event.spec.js
@@ -7,6 +7,7 @@ const { test, expect } = require( '@playwright/test' );
  * Internal dependencies
  */
 import { findSnaptrEvent, getThemes, switchTheme } from '../../../utils';
+import { integration } from '../../../config';
 
 test.describe( 'VIEW_CONTENT event', () => {
 	test.use( { storageState: process.env.ADMINSTATE } );
@@ -25,7 +26,7 @@ test.describe( 'VIEW_CONTENT event', () => {
 
 			const [ , , payload ] = VIEW_CONTENT;
 
-			expect( payload.integration ).toBe( 'woocommerce-v1' );
+			expect( payload.integration ).toBe( integration );
 			expect( payload.price ).toBe( 15 );
 			expect( payload.currency ).toBe( 'USD' );
 			expect( payload.item_ids ).toContain( 11 );
@@ -48,7 +49,7 @@ test.describe( 'VIEW_CONTENT event', () => {
 
 			const [ , , payload ] = VIEW_CONTENT;
 
-			expect( payload.integration ).toBe( 'woocommerce-v1' );
+			expect( payload.integration ).toBe( integration );
 			expect( payload.price ).toBe( 15 );
 			expect( payload.currency ).toBe( 'USD' );
 			expect( payload.item_ids ).toContain( 11 );
@@ -79,7 +80,7 @@ test.describe( 'VIEW_CONTENT event', () => {
 
 			const [ , , payload ] = VIEW_CONTENT;
 
-			expect( payload.integration ).toBe( 'woocommerce-v1' );
+			expect( payload.integration ).toBe( integration );
 			expect( payload.price ).toBe( 15 );
 			expect( payload.currency ).toBe( 'USD' );
 			expect( payload.item_ids ).toContain( 11 );


### PR DESCRIPTION
### Changes proposed in this Pull Request:
As requested in SNAPWOO-70, this PR changes the integration value sent in the Pixel and CAPI event payload from `woocommerce-v1` to the `woocommerce-v1-0-0` format, which always includes the current plugin version (e.g., `woocommerce-v1-0-2` for the current version).

Closes https://linear.app/a8c/issue/SNAPWOO-70/add-the-plugin-version-number-to-the-url-parameter-we-send-to-snapchat

### Steps to test the changes in this Pull Request:
Verify that all Pixel and CAPI event payloads send the integration value as `woocommerce-v1-0-2`.

### Changelog entry
> Update – Integration value in event payload to include the current plugin version.