### PR TITLE
Add deploy workflow to the repo.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,76 @@
+name: Deploy Plugin
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to deploy (e.g., 1.0.0)'
+        required: true
+        type: string
+      deploy_wporg:
+        description: 'Deploy to WordPress.org'
+        required: false
+        default: true
+        type: boolean
+      deploy_github:
+        description: 'Deploy to GitHub'
+        required: false
+        default: true
+        type: boolean
+      simulate:
+        description: 'Dry run mode'
+        required: false
+        default: true
+        type: boolean
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout the private action repository
+      - name: Checkout woo-product-deploy action
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # 4.3.0
+        with:
+          repository: woocommerce/woo-product-deploy
+          ref: trunk
+          path: ./.github/actions/woo-product-deploy
+          token: ${{ secrets.ORG_DEPLOY_SECRET }}  # Need PAT with access to the action repository
+
+      # Use the action we checked out
+      - name: Deploy Product
+        uses: ./.github/actions/woo-product-deploy
+        with:
+          repo_url: https://github.com/woocommerce/snapchat-for-woocommerce
+          branch: ${{ github.ref_name }}
+          version: ${{ github.event.inputs.version }}
+          node_version: '20'
+          npm_version: '10'
+          simulate: ${{ github.event.inputs.simulate }}
+          github_release: ${{ github.event.inputs.deploy_github }}
+          wporg_release: ${{ github.event.inputs.deploy_wporg }}
+          wporg_username: ${{ secrets.WPORG_USERNAME }}
+          wporg_password: ${{ secrets.WPORG_PASSWORD }}
+          deploy_pat: ${{ secrets.ORG_DEPLOY_SECRET }}
+          partner_user: ${{ secrets.ORG_PARTNER_USER }}
+          partner_secret: ${{ secrets.ORG_PARTNER_DEPLOY_SECRET }}
+
+      - name: Copy build zip and preview changes
+        run: |
+          TEMP_DIR=$(php -r 'echo sys_get_temp_dir();')
+          SIMULATE=${{ github.event.inputs.simulate }}
+
+          cd "$TEMP_DIR/snapchat-for-woocommerce"
+          cp snapchat-for-woocommerce.zip ${{ github.workspace }}
+
+          # Show git diff if it's a dry run
+          if [ "$SIMULATE" == "true" ]; then
+            git --no-pager diff
+          fi
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: snapchat-for-woocommerce.zip
+          path: ${{ github.workspace }}/snapchat-for-woocommerce.zip
+          retention-days: 1


### PR DESCRIPTION
This adds the GitHub deploy workflow that will deploy a release build of the plugin to WP.org and create a release on GitHub. 

This workflow can be triggered from any branch, but is best used in combination with the existing [Prepare New Release](https://github.com/woocommerce/snapchat-for-woocommerce/blob/trunk/.github/workflows/prepare-release.yml) workflow, which will stage a release branch prior to release.

See SNAPWOO-69