### PR TITLE
Compatibility testing with WC 10.5

### DIFF
--- a/snapchat-for-woocommerce.php
+++ b/snapchat-for-woocommerce.php
@@ -12,8 +12,8 @@
  * PHP tested up to: 8.4
  * Requires at least: 6.7
  * Tested up to: 6.9
- * WC requires at least: 10.2
- * WC tested up to: 10.4
+ * WC requires at least: 10.3
+ * WC tested up to: 10.5
  *
  * License: GNU General Public License v3.0
  * License URI: http://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
## Compatibility testing with WooCommerce 10.5

### Summary
Updates plugin compatibility metadata for WooCommerce 10.5 testing.

Closes https://linear.app/a8c/issue/SNAPWOO-72/compatibility-testing-with-woo-105-beta

### Changes
- **WC Tested up to:** 10.4 → 10.5
- **WC requires at least:** 10.2 → 10.3
- **WordPress Requires at least:** 6.7 (unchanged)
- **Requires PHP:** 7.4 (unchanged)

### Notes
- No `MINIMUM_PHP_VERSION`, `MINIMUM_WP_VERSION`, or `MINIMUM_WC_VERSION` constants exist in the codebase; all requirements are declared in the plugin header only.
- Ready for compatibility testing with WooCommerce 10.5.
