### PR TITLE
Load snapchat assets on any wp-admin route

### DIFF
--- a/includes/Admin/Assets.php
+++ b/includes/Admin/Assets.php
@@ -59,10 +59,10 @@ class Assets {
 	public function enqueue_assets(): void {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$page = sanitize_text_field( wp_unslash( $_GET['page'] ?? '' ) );
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$path = sanitize_text_field( wp_unslash( $_GET['path'] ?? '' ) );
 
-		if ( ! ( 'wc-admin' === $page && str_contains( $path, '/snapchat' ) ) ) {
+		// Load assets on any WC Admin page to support SPA navigation.
+		// The React router will handle showing the correct components based on the actual route.
+		if ( 'wc-admin' !== $page ) {
 			return;
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Loads Snapchat for Woocommerce assets on /wc-admin routes to make SPA navigation work.

Since WooCommerce routes use JavaScript-based navigation, the PHP logic that checks the current route to load Snapchat assets doesn't execute when navigating from one WooCommerce subpage to another. As in the Google for Woocommerce plugin, the assets should be loaded under any Woocommerce route.

Closes https://linear.app/a8c/issue/SNAPWOO-74/error-loading-main-plugin-page-from-menu

### Screenshots:

<!--- Optional --->


### Detailed test instructions:

**Important:** You need to use a publicly accessible URL e.g. Ngrok; local URL's (e.g. `woo.test`) will not work.

1. Have both the Google and Snapchat for Woocommerce plugins installed
2. Go to Marketing > Overview in the admin
3. Navigate to Marketing > Snapchat
4. There shouldn't be a routing error ('Not allowed' message) anymore


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry
Prevent adblockers from blocking auto-generated images in the preview
> Fix routing navigation within the Woocommerce plugin admin