### PR TITLE
[SNAPWOO-71] Strip HTML from product description for the CSV export.

### DIFF
--- a/includes/Admin/Export/RowBuilder/ProductRowBuilder.php
+++ b/includes/Admin/Export/RowBuilder/ProductRowBuilder.php
@@ -84,7 +84,7 @@ class ProductRowBuilder implements ExportRowBuilderInterface {
 		$row = array(
 			'id'           => (string) $product->get_id(),
 			'title'        => $product->get_name(),
-			'description'  => $product->get_description(),
+			'description'  => wp_strip_all_tags( $product->get_description() ),
 			'link'         => get_permalink( $product->get_id() ),
 			'image_link'   => $image_url,
 			/**

--- a/tests/Unit/Admin/Export/RowBuilder/ProductRowBuilderTest.php
+++ b/tests/Unit/Admin/Export/RowBuilder/ProductRowBuilderTest.php
@@ -42,6 +42,8 @@ class ProductRowBuilderTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'title', $row );
 		$this->assertArrayHasKey( 'price', $row );
 		$this->assertArrayHasKey( 'availability', $row );
+		$this->assertArrayHasKey( 'description', $row );
+		$this->assertSame( 'Test Description', $row['description'] ); // stripped of HTML
 	}
 
 	/**
@@ -67,6 +69,7 @@ class ProductRowBuilderTest extends WP_UnitTestCase {
 	private function create_test_product( array $props = array() ) {
 		$product = new \WC_Product_Simple();
 		$product->set_name( 'Test Product' );
+		$product->set_description( '<p>Test Description</p>' );
 		$product->set_regular_price( '199.99' );
 		$product->save();
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:
PR make changes to strip HTML tags from the product description to avoid errors during product import on Reddit.

Closes https://linear.app/a8c/issue/SNAPWOO-71/product-descriptions-containing-images-perhaps-any-rich-text-cannot-be

### Steps to test the changes in this Pull Request:
1. Create products with HTML in the description (add images, list items, etc.).
2. Complete the plugin onboarding process and verify that all products are imported successfully on the Snapchat side without any issues - any HTML should be stripped out.

### Changelog entry
> Fix - Strip HTML tags from the product description for the CSV export.