### PR TITLE
Compatibility testing with WC 10.6

### DIFF
--- a/snapchat-for-woocommerce.php
+++ b/snapchat-for-woocommerce.php
@@ -10,10 +10,10 @@
  * Requires Plugins: woocommerce
  * Requires PHP: 7.4
  * PHP tested up to: 8.4
- * Requires at least: 6.7
+ * Requires at least: 6.8
  * Tested up to: 6.9
- * WC requires at least: 10.2
- * WC tested up to: 10.4
+ * WC requires at least: 10.4
+ * WC tested up to: 10.6
  *
  * License: GNU General Public License v3.0
  * License URI: http://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
### All Submissions:

* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---
### Changes proposed in this Pull Request:

- Bump WooCommerce "tested up to" version 10.6
- Bump WooCommerce minimum supported version to 10.4
- Bump WordPress minimum supported version to 6.8.

Closes https://linear.app/a8c/issue/SNAPWOO-81/compatibility-testing-with-woo-106-beta



### Changelog entry

> Dev - Bump WooCommerce "tested up to" version 10.6
> Dev - Bump WooCommerce minimum supported version to 10.4
> Dev - Bump WordPress minimum supported version to 6.8.

