### PR TITLE
[SNAPWOO-16] Optimise script loading

### DIFF
--- a/includes/Admin/Export/EntityProvider/ProductEntityProvider.php
+++ b/includes/Admin/Export/EntityProvider/ProductEntityProvider.php
@@ -82,6 +82,8 @@ class ProductEntityProvider implements ExportableEntityProviderInterface {
 		return wc_get_products(
 			array(
 				'include' => $ids,
+				'orderby' => 'include',
+				'order'   => 'ASC',
 				'return'  => 'objects',
 				'limit'   => count( $ids ),
 			)

--- a/includes/Tracking/PixelTrackingService.php
+++ b/includes/Tracking/PixelTrackingService.php
@@ -14,7 +14,7 @@ namespace SnapchatForWooCommerce\Tracking;
 use SnapchatForWooCommerce\Utils\Storage\OptionDefaults;
 use SnapchatForWooCommerce\Utils\Storage\Options;
 use SnapchatForWooCommerce\Utils\Helper;
-use SnapchatForWooCommerce\Config;
+
 use WC_Product;
 
 /**
@@ -172,12 +172,9 @@ final class PixelTrackingService implements ServiceStatusInterface {
 			$this->filter_page_view_event_data( $tracking_data );
 		}
 
-		wp_add_inline_script(
-			Config::ASSET_HANDLE_PREFIX . 'tracking',
-			'
-			window.snapchatAdsTrackingData = window.snapchatAdsTrackingData || {};
-			window.snapchatAdsTrackingData = Object.assign( window.snapchatAdsTrackingData, ' . wp_json_encode( $tracking_data ) . ' );
-			'
+		wp_print_inline_script_tag(
+			'window.snapchatAdsTrackingData = window.snapchatAdsTrackingData || {};'
+			. 'window.snapchatAdsTrackingData = Object.assign( window.snapchatAdsTrackingData, ' . wp_json_encode( $tracking_data ) . ' );'
 		);
 	}
 

--- a/includes/Tracking/RemotePixelTracker.php
+++ b/includes/Tracking/RemotePixelTracker.php
@@ -19,7 +19,7 @@ use SnapchatForWooCommerce\Utils\Storage\TransientDefaults;
 use SnapchatForWooCommerce\Utils\Storage;
 use SnapchatForWooCommerce\Tracking\Consent;
 use SnapchatForWooCommerce\Utils\UserIdentifier;
-use SnapchatForWooCommerce\Config;
+
 
 /**
  * Fetches and injects Snapchat pixel tracking code into WooCommerce frontend pages.
@@ -265,6 +265,6 @@ final class RemotePixelTracker implements PixelTrackerInterface {
 			wp_json_encode( $payload )
 		);
 
-		wp_add_inline_script( Config::ASSET_HANDLE_PREFIX . 'tracking', $tracking_data );
+		wp_print_inline_script_tag( $tracking_data );
 	}
 }

--- a/includes/Utils/AssetLoader.php
+++ b/includes/Utils/AssetLoader.php
@@ -52,7 +52,9 @@ class AssetLoader {
 			$script_url,
 			$asset_data['dependencies'],
 			$asset_data['version'],
-			true
+			array(
+				'strategy' => 'defer',
+			)
 		);
 	}
 

--- a/tests/Unit/Admin/Export/Service/ProductExportServiceTest.php
+++ b/tests/Unit/Admin/Export/Service/ProductExportServiceTest.php
@@ -148,8 +148,6 @@ class ProductExportServiceTest extends WP_UnitTestCase {
 		$this->assertNotEmpty( $file_path );
 		$this->assertFileExists( $file_path );
 
-		$this->assertFileExists( $file_path );
-
 		$csv = array_map(
 			static function( $line ) {
 				return str_getcsv( $line, ',', '"', '\\' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/SNAPWOO-16/optimize-script-loading

### Screenshots:

N/A


### Detailed test instructions:

1. Open a storefront page (e.g. shop, single product, or cart).
2. View Page Source (Cmd+U / Ctrl+U).
3. Search for`snapchat_tracking`.
- Verify: The <script> tag is inside <head>, not at the bottom of <body>.
- Verify: The tag has a defer attribute (e.g. <script defer ...>).
4. Localized data still available
- On the same storefront page, open DevTools Console.
- Type `window.snapchatAdsTrackingData` and press Enter.
- Verify: The object exists and contains `is_pixel_enabled`, `is_conversion_enabled`, `capi_nonce`
7. Admin page functions normally
On the Snapchat admin page, verify the React UI renders (onboarding or settings/export tabs depending on connection state).
If connected, click through Settings and Export tabs.
Verify: No console errors related to snapchatAdsAdminData being undefined.
8. Tracking disabled -- no scripts loaded
Disable both Pixel and Conversion API tracking in the plugin settings (or disconnect).
Load a storefront page and View Page Source.
Verify: No snapchat_tracking script tag appears at all.


### Additional details:

> Update - Optimise script loading