### PR TITLE
Updated copy of the "Disconnect Snapchat" modal

### DIFF
--- a/js/src/pages/settings/disconnect-modal/confirm-modal.js
+++ b/js/src/pages/settings/disconnect-modal/confirm-modal.js
@@ -38,10 +38,7 @@ const textDict = {
 		],
 	},
 	[ SNAPCHAT_ACCOUNT ]: {
-		title: __(
-			'Disconnect Snapchat account?',
-			'snapchat-for-woocommerce'
-		),
+		title: __( 'Disconnect Snapchat account?', 'snapchat-for-woocommerce' ),
 		confirmButton: __(
 			'Disconnect Snapchat account',
 			'snapchat-for-woocommerce'

--- a/js/src/pages/settings/disconnect-modal/confirm-modal.js
+++ b/js/src/pages/settings/disconnect-modal/confirm-modal.js
@@ -38,9 +38,12 @@ const textDict = {
 		],
 	},
 	[ SNAPCHAT_ACCOUNT ]: {
-		title: __( 'Disconnect Snapchat account', 'snapchat-for-woocommerce' ),
+		title: __(
+			'Disconnect Snapchat account?',
+			'snapchat-for-woocommerce'
+		),
 		confirmButton: __(
-			'Disconnect Snapchat Account',
+			'Disconnect Snapchat account',
 			'snapchat-for-woocommerce'
 		),
 		confirmation: __(
@@ -49,15 +52,11 @@ const textDict = {
 		),
 		contents: [
 			__(
-				'I understand that I am disconnecting my Snapchat account from this WooCommerce extension.',
+				'Your Snapchat account will be disconnected from your WooCommerce store. Some Snapchat settings created in WooCommerce may be lost and can’t be restored.',
 				'snapchat-for-woocommerce'
 			),
 			__(
-				'Some configurations for Snapchat created through WooCommerce may be lost. This cannot be undone.',
-				'snapchat-for-woocommerce'
-			),
-			__(
-				'Your catalog will remain in your Snapchat Business Account and can still be used to run Ads.',
+				'Your catalog will remain in your Snapchat Business Account.',
 				'snapchat-for-woocommerce'
 			),
 		],
@@ -131,7 +130,7 @@ export default function ConfirmModal( {
 					disabled={ isDisconnecting }
 					onClick={ handleRequestClose }
 				>
-					{ __( 'Never mind', 'snapchat-for-woocommerce' ) }
+					{ __( 'Cancel', 'snapchat-for-woocommerce' ) }
 				</AppButton>,
 				<AppButton
 					key="2"

--- a/tests/e2e/utils/element-locators.js
+++ b/tests/e2e/utils/element-locators.js
@@ -122,7 +122,7 @@ export default class ElementLocators {
 	getSnapchatDisconnectModal() {
 		return this.page.locator( '.sfw-disconnect-accounts-modal', {
 			hasText:
-				'I understand that I am disconnecting my Snapchat account from this WooCommerce extension.',
+				'Your Snapchat account will be disconnected from your WooCommerce store.',
 		} );
 	}
 
@@ -144,7 +144,7 @@ export default class ElementLocators {
 	 */
 	getSnapchatFinalDisconnectButton() {
 		return this.getSnapchatDisconnectModal().getByRole( 'button', {
-			name: 'Disconnect Snapchat Account',
+			name: 'Disconnect Snapchat account',
 		} );
 	}
 


### PR DESCRIPTION
### Description

This PR updates the copy of the modal that shows up when disconnecting the Snapchat account. 

Closes: [SNAPWOO-85: Update copy in the disconnect Snapchat account modal](https://linear.app/a8c/issue/SNAPWOO-85/update-copy-in-the-disconnect-snapchat-account-modal)

Old copy: 

<img width="1778" height="1214" alt="Markup on 2026-04-02 at 14:57:36" src="https://github.com/user-attachments/assets/9addba75-6850-4974-95b8-2c7afc6d86ad" />

New copy:

<img width="1636" height="1078" alt="Markup on 2026-04-02 at 15:26:55" src="https://github.com/user-attachments/assets/a2350f1e-eada-44e3-9f56-6a8ea5a6be6b" />

### Testing instructions

1. Connect your site to Snapchat. 
2. Go to Marketing > Snapchat. 
3. Click to disconnect your site. 
4. Ensure that you see the new modal. 

### Additional details:

> Tweak - Updated the "Disconnect" confirmation modal.