### PR TITLE
Ensure existing catalog ID is used on reconnect where possible.

### DIFF
--- a/includes/API/AdPartner/CatalogApi.php
+++ b/includes/API/AdPartner/CatalogApi.php
@@ -22,6 +22,7 @@ use SnapchatForWooCommerce\Utils\Storage\Options;
 use SnapchatForWooCommerce\Utils\Storage\OptionDefaults;
 use SnapchatForWooCommerce\Utils\Helper;
 use WP_Error;
+use WP_REST_Response;
 
 /**
  * API module for managing product catalogs.
@@ -91,5 +92,180 @@ class CatalogApi extends BaseAdPartnerApi {
 		);
 
 		return $response;
+	}
+
+	/**
+	 * Retrieves a single catalog by ID.
+	 *
+	 * Used to verify that a locally-stored catalog ID still corresponds to an
+	 * existing catalog on the Ad Partner side before deciding whether to create
+	 * a new one.
+	 *
+	 * @since 1.0.3
+	 *
+	 * @param string $catalog_id Catalog ID to look up.
+	 *
+	 * @return \WP_REST_Response|WP_Error REST response from WCS, or error on invalid
+	 *                                    input or remote failure (including HTTP 404).
+	 */
+	public function get_catalog( string $catalog_id ) {
+		if ( '' === $catalog_id ) {
+			return new WP_Error(
+				'catalog_id_empty',
+				__( 'Catalog ID is required.', 'snapchat-for-woocommerce' ),
+			);
+		}
+
+		return $this->wcs->proxy_get(
+			'/ads/v1/catalogs/' . rawurlencode( $catalog_id )
+		);
+	}
+
+	/**
+	 * Returns an existing catalog when the stored catalog ID is still valid on
+	 * the Ad Partner side AND matches the currently-connected organization and
+	 * pixel, otherwise creates a new one.
+	 *
+	 * Prevents duplicate catalog creation on disconnect + reconnect cycles by
+	 * verifying the previously stored `CATALOG_ID` option against the Ad
+	 * Partner before falling back to {@see self::create()}.
+	 *
+	 * Reuse is rejected (and a fresh catalog is created) in any of these cases:
+	 *  - no `CATALOG_ID` is stored (first-time connect);
+	 *  - `get_catalog()` returns a WP_Error (e.g. HTTP 404 for a deleted catalog);
+	 *  - the GET response is 2xx but the body is not shaped as Snap's catalog
+	 *    envelope (malformed upstream);
+	 *  - the stored catalog belongs to a different organization than the one
+	 *    currently in `ORGANIZATION_ID` (user reconnected against a different
+	 *    Snapchat org);
+	 *  - the stored catalog is not attached to the current `PIXEL_ID` (user
+	 *    reconnected with a different pixel selected).
+	 *
+	 * Snap's `GET /v1/catalogs/{id}` returns the same "bulk" envelope as its
+	 * `POST /v1/organizations/{org_id}/catalogs`, so the response from
+	 * {@see self::get_catalog()} can be passed straight back to the caller
+	 * without re-wrapping: `{ request_status, request_id, catalogs: [ {
+	 * sub_request_status, catalog: {...} } ] }`.
+	 *
+	 * Every rejection branch emits a warning to the WooCommerce log (source
+	 * `snapchat-for-woocommerce`, gated on `SNAPCHAT_FOR_WOOCOMMERCE_DEBUG`)
+	 * explaining why the stored catalog was discarded — useful for diagnosing
+	 * "a new catalog was created after reconnect" support reports.
+	 *
+	 * @since 1.0.3
+	 *
+	 * @return \WP_REST_Response|WP_Error REST response wrapping the catalog,
+	 *                                    or a WP_Error if create() fails.
+	 */
+	public function find_or_create() {
+		$stored_id = Options::get( OptionDefaults::CATALOG_ID );
+
+		if ( empty( $stored_id ) ) {
+			return $this->create();
+		}
+
+		$existing = $this->get_catalog( $stored_id );
+
+		if ( is_wp_error( $existing ) ) {
+			$this->log_stale_catalog(
+				$stored_id,
+				sprintf(
+					'get_catalog returned WP_Error (code=%1$s, message=%2$s)',
+					$existing->get_error_code(),
+					$existing->get_error_message()
+				)
+			);
+			return $this->create();
+		}
+
+		$data    = $existing->get_data();
+		$catalog = ( isset( $data['catalogs'][0]['catalog'] ) && is_array( $data['catalogs'][0]['catalog'] ) )
+			? $data['catalogs'][0]['catalog']
+			: null;
+
+		if ( null === $catalog ) {
+			$this->log_stale_catalog( $stored_id, 'GET /catalogs/{id} returned a 2xx without a catalogs[0].catalog object' );
+			return $this->create();
+		}
+
+		$org_id        = Options::get( OptionDefaults::ORGANIZATION_ID );
+		$pixel_id      = Options::get( OptionDefaults::PIXEL_ID );
+		$remote_org_id = isset( $catalog['organization_id'] ) ? (string) $catalog['organization_id'] : '';
+
+		if ( empty( $org_id ) || '' === $remote_org_id || $remote_org_id !== $org_id ) {
+			$this->log_stale_catalog(
+				$stored_id,
+				sprintf(
+					'organization mismatch (local=%1$s, remote=%2$s)',
+					self::format( $org_id ),
+					self::format( $remote_org_id )
+				)
+			);
+			return $this->create();
+		}
+
+		$event_sources    = ( isset( $catalog['event_sources'] ) && is_array( $catalog['event_sources'] ) ) ? $catalog['event_sources'] : array();
+		$event_source_ids = array_column( $event_sources, 'id' );
+
+		if ( empty( $pixel_id ) || ! in_array( $pixel_id, $event_source_ids, true ) ) {
+			$this->log_stale_catalog(
+				$stored_id,
+				sprintf(
+					'pixel not attached to stored catalog (local_pixel=%1$s, remote_event_source_ids=%2$s)',
+					self::format( $pixel_id ),
+					wp_json_encode( $event_source_ids )
+				)
+			);
+			return $this->create();
+		}
+
+		return $existing;
+	}
+
+	/**
+	 * Logs a warning that the stored `CATALOG_ID` is unusable and a new catalog
+	 * will be created in its place. Gated on the plugin's debug flag so it is a
+	 * no-op in normal production use.
+	 *
+	 * @since 1.0.3
+	 *
+	 * @param string $catalog_id The stored catalog ID that was rejected.
+	 * @param string $reason     Human-readable reason for rejection.
+	 *
+	 * @return void
+	 */
+	private function log_stale_catalog( string $catalog_id, string $reason ): void {
+		if ( ! Helper::is_logging_enabled() ) {
+			return;
+		}
+
+		$logger = wc_get_logger();
+		$logger->warning(
+			sprintf(
+				'Creating new Snapchat catalog (stored id "%1$s" unusable): %2$s',
+				$catalog_id,
+				$reason
+			),
+			array( 'source' => 'snapchat-for-woocommerce' )
+		);
+	}
+
+	/**
+	 * Renders a value safely for log output. Empty strings, nulls and booleans
+	 * are stringified explicitly so log entries read "local=(empty)" rather
+	 * than the ambiguous "local=".
+	 *
+	 * @since 1.0.3
+	 *
+	 * @param mixed $value Value to render.
+	 *
+	 * @return string
+	 */
+	private static function format( $value ): string {
+		if ( '' === $value || null === $value || false === $value ) {
+			return '(empty)';
+		}
+
+		return (string) $value;
 	}
 }

--- a/includes/API/Site/Controllers/SnapchatBusinessExtensionController.php
+++ b/includes/API/Site/Controllers/SnapchatBusinessExtensionController.php
@@ -224,7 +224,7 @@ class SnapchatBusinessExtensionController extends RESTBaseController {
 
 		Options::set( OptionDefaults::ONBOARDING_STATUS, 'connected' );
 
-		$response = $this->ad_partner_api->catalog->create();
+		$response = $this->ad_partner_api->catalog->find_or_create();
 
 		if ( is_wp_error( $response ) ) {
 			return new WP_REST_Response(

--- a/tests/Unit/API/AdPartner/CatalogApiTest.php
+++ b/tests/Unit/API/AdPartner/CatalogApiTest.php
@@ -1,0 +1,405 @@
+<?php
+/**
+ * Unit tests for CatalogApi.
+ *
+ * Covers the SNAPWOO-75 fix: `find_or_create()` reuses a stored catalog ID
+ * only when it still resolves on the Ad Partner side AND matches the
+ * currently-connected organization and pixel, and falls back to `create()`
+ * in every other case (no stored ID, 404, transient error, malformed 2xx,
+ * org mismatch, pixel mismatch).
+ *
+ * @package SnapchatForWooCommerce\Tests\Unit\API\AdPartner
+ */
+
+namespace SnapchatForWooCommerce\Tests\Unit\API\AdPartner;
+
+use WP_Error;
+use WP_REST_Response;
+use WP_UnitTestCase;
+use SnapchatForWooCommerce\API\AdPartner\CatalogApi;
+use SnapchatForWooCommerce\Connection\WcsClient;
+use SnapchatForWooCommerce\Utils\Storage\Options;
+use SnapchatForWooCommerce\Utils\Storage\OptionDefaults;
+
+/**
+ * @covers \SnapchatForWooCommerce\API\AdPartner\CatalogApi
+ */
+class CatalogApiTest extends WP_UnitTestCase {
+
+	/**
+	 * Reset options that the tests mutate.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		Options::delete( OptionDefaults::CATALOG_ID );
+		Options::delete( OptionDefaults::ORGANIZATION_ID );
+		Options::delete( OptionDefaults::PIXEL_ID );
+	}
+
+	/**
+	 * Test: `get_catalog()` returns WP_Error for an empty catalog ID without hitting WCS.
+	 */
+	public function test_get_catalog_returns_error_for_empty_id(): void {
+		$wcs = $this->createMock( WcsClient::class );
+		$wcs->expects( $this->never() )->method( 'proxy_get' );
+
+		$api    = new CatalogApi( $wcs );
+		$result = $api->get_catalog( '' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'catalog_id_empty', $result->get_error_code() );
+	}
+
+	/**
+	 * Test: `get_catalog()` proxies GET to `/ads/v1/catalogs/{id}` with the ID URL-encoded.
+	 */
+	public function test_get_catalog_proxies_to_correct_endpoint(): void {
+		$wcs = $this->createMock( WcsClient::class );
+		$wcs->expects( $this->once() )
+			->method( 'proxy_get' )
+			->with( '/ads/v1/catalogs/abc-123' )
+			->willReturn(
+				new WP_REST_Response(
+					array(
+						'catalogs' => array(
+							array(
+								'sub_request_status' => 'SUCCESS',
+								'catalog'            => array( 'id' => 'abc-123' ),
+							),
+						),
+					),
+					200
+				)
+			);
+
+		$api    = new CatalogApi( $wcs );
+		$result = $api->get_catalog( 'abc-123' );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $result );
+	}
+
+	/**
+	 * Test: `find_or_create()` skips the lookup and calls `create()` when no
+	 * `CATALOG_ID` is stored (first-time connect).
+	 */
+	public function test_find_or_create_calls_create_when_no_stored_id(): void {
+		$wcs = $this->createMock( WcsClient::class );
+
+		$api = $this->getMockBuilder( CatalogApi::class )
+			->setConstructorArgs( array( $wcs ) )
+			->onlyMethods( array( 'get_catalog', 'create' ) )
+			->getMock();
+
+		$api->expects( $this->never() )->method( 'get_catalog' );
+
+		$create_response = new WP_REST_Response(
+			array(
+				'catalogs' => array(
+					array(
+						'catalog' => array( 'id' => 'new-id' ),
+					),
+				),
+			)
+		);
+		$api->expects( $this->once() )->method( 'create' )->willReturn( $create_response );
+
+		$result = $api->find_or_create();
+
+		$this->assertSame( $create_response, $result );
+	}
+
+	/**
+	 * Test: `find_or_create()` reuses the stored `CATALOG_ID` when `get_catalog()`
+	 * confirms it still exists AND the catalog's organization + pixel match the
+	 * currently-connected values. Snap's GET envelope already matches the POST
+	 * envelope, so the response is passed straight through to the caller.
+	 */
+	public function test_find_or_create_reuses_existing_id_when_get_catalog_succeeds(): void {
+		Options::set( OptionDefaults::CATALOG_ID, 'existing-id' );
+		Options::set( OptionDefaults::ORGANIZATION_ID, 'org-xyz' );
+		Options::set( OptionDefaults::PIXEL_ID, 'pixel-abc' );
+
+		$wcs = $this->createMock( WcsClient::class );
+
+		$api = $this->getMockBuilder( CatalogApi::class )
+			->setConstructorArgs( array( $wcs ) )
+			->onlyMethods( array( 'get_catalog', 'create' ) )
+			->getMock();
+
+		$catalog_payload = array(
+			'id'              => 'existing-id',
+			'name'            => 'Example Store',
+			'vertical'        => 'COMMERCE',
+			'organization_id' => 'org-xyz',
+			'event_sources'   => array(
+				array(
+					'id'   => 'pixel-abc',
+					'type' => 'PIXEL',
+				),
+			),
+		);
+
+		// Real Snap `GET /v1/catalogs/{id}` shape matches POST: plural `catalogs`
+		// array with each entry wrapping a singular `catalog` object.
+		$get_response = new WP_REST_Response(
+			array(
+				'request_status' => 'SUCCESS',
+				'request_id'     => 'req-abc',
+				'catalogs'       => array(
+					array(
+						'sub_request_status' => 'SUCCESS',
+						'catalog'            => $catalog_payload,
+					),
+				),
+			),
+			200
+		);
+
+		$api->expects( $this->once() )
+			->method( 'get_catalog' )
+			->with( 'existing-id' )
+			->willReturn( $get_response );
+
+		$api->expects( $this->never() )->method( 'create' );
+
+		$result = $api->find_or_create();
+
+		// The GET response is returned verbatim — no re-wrapping needed.
+		$this->assertSame( $get_response, $result );
+
+		$data = $result->get_data();
+		$this->assertSame( $catalog_payload, $data['catalogs'][0]['catalog'] );
+	}
+
+	/**
+	 * Test: `find_or_create()` creates a new catalog when the stored catalog's
+	 * `organization_id` does not match the currently-connected organization.
+	 *
+	 * Covers the reconnect-against-a-different-org case where blindly reusing
+	 * the stored ID would leave local state pointing at a catalog that belongs
+	 * to someone else's org.
+	 */
+	public function test_find_or_create_creates_new_when_organization_mismatches(): void {
+		Options::set( OptionDefaults::CATALOG_ID, 'existing-id' );
+		Options::set( OptionDefaults::ORGANIZATION_ID, 'org-current' );
+		Options::set( OptionDefaults::PIXEL_ID, 'pixel-current' );
+
+		$wcs = $this->createMock( WcsClient::class );
+
+		$api = $this->getMockBuilder( CatalogApi::class )
+			->setConstructorArgs( array( $wcs ) )
+			->onlyMethods( array( 'get_catalog', 'create' ) )
+			->getMock();
+
+		$api->method( 'get_catalog' )->willReturn(
+			new WP_REST_Response(
+				array(
+					'catalogs' => array(
+						array(
+							'sub_request_status' => 'SUCCESS',
+							'catalog'            => array(
+								'id'              => 'existing-id',
+								'organization_id' => 'org-different',
+								'event_sources'   => array(
+									array(
+										'id'   => 'pixel-current',
+										'type' => 'PIXEL',
+									),
+								),
+							),
+						),
+					),
+				),
+				200
+			)
+		);
+
+		$create_response = new WP_REST_Response(
+			array(
+				'catalogs' => array(
+					array(
+						'catalog' => array( 'id' => 'fresh-id' ),
+					),
+				),
+			)
+		);
+		$api->expects( $this->once() )->method( 'create' )->willReturn( $create_response );
+
+		$result = $api->find_or_create();
+
+		$this->assertSame( $create_response, $result );
+	}
+
+	/**
+	 * Test: `find_or_create()` creates a new catalog when the current `PIXEL_ID`
+	 * is not listed in the stored catalog's `event_sources`.
+	 *
+	 * Covers the reconnect-with-different-pixel case: the stored catalog still
+	 * exists and is in the right org, but it is wired to a pixel the user is
+	 * no longer using.
+	 */
+	public function test_find_or_create_creates_new_when_pixel_not_in_event_sources(): void {
+		Options::set( OptionDefaults::CATALOG_ID, 'existing-id' );
+		Options::set( OptionDefaults::ORGANIZATION_ID, 'org-current' );
+		Options::set( OptionDefaults::PIXEL_ID, 'pixel-new' );
+
+		$wcs = $this->createMock( WcsClient::class );
+
+		$api = $this->getMockBuilder( CatalogApi::class )
+			->setConstructorArgs( array( $wcs ) )
+			->onlyMethods( array( 'get_catalog', 'create' ) )
+			->getMock();
+
+		$api->method( 'get_catalog' )->willReturn(
+			new WP_REST_Response(
+				array(
+					'catalogs' => array(
+						array(
+							'sub_request_status' => 'SUCCESS',
+							'catalog'            => array(
+								'id'              => 'existing-id',
+								'organization_id' => 'org-current',
+								'event_sources'   => array(
+									array(
+										'id'   => 'pixel-old',
+										'type' => 'PIXEL',
+									),
+								),
+							),
+						),
+					),
+				),
+				200
+			)
+		);
+
+		$create_response = new WP_REST_Response(
+			array(
+				'catalogs' => array(
+					array(
+						'catalog' => array( 'id' => 'fresh-id' ),
+					),
+				),
+			)
+		);
+		$api->expects( $this->once() )->method( 'create' )->willReturn( $create_response );
+
+		$result = $api->find_or_create();
+
+		$this->assertSame( $create_response, $result );
+	}
+
+	/**
+	 * Test: `find_or_create()` creates a new catalog when `get_catalog()` returns
+	 * a 2xx response that is missing the `catalog` object (malformed upstream).
+	 *
+	 * We can't trust a "valid" lookup without the catalog payload, so we fall
+	 * through to `create()` rather than persisting partial state.
+	 */
+	public function test_find_or_create_creates_new_when_response_missing_catalog_key(): void {
+		Options::set( OptionDefaults::CATALOG_ID, 'existing-id' );
+		Options::set( OptionDefaults::ORGANIZATION_ID, 'org-current' );
+		Options::set( OptionDefaults::PIXEL_ID, 'pixel-current' );
+
+		$wcs = $this->createMock( WcsClient::class );
+
+		$api = $this->getMockBuilder( CatalogApi::class )
+			->setConstructorArgs( array( $wcs ) )
+			->onlyMethods( array( 'get_catalog', 'create' ) )
+			->getMock();
+
+		$api->method( 'get_catalog' )->willReturn(
+			new WP_REST_Response( array( 'request_status' => 'SUCCESS' ), 200 )
+		);
+
+		$create_response = new WP_REST_Response(
+			array(
+				'catalogs' => array(
+					array(
+						'catalog' => array( 'id' => 'fresh-id' ),
+					),
+				),
+			)
+		);
+		$api->expects( $this->once() )->method( 'create' )->willReturn( $create_response );
+
+		$result = $api->find_or_create();
+
+		$this->assertSame( $create_response, $result );
+	}
+
+	/**
+	 * Test: `find_or_create()` falls back to `create()` when `get_catalog()` returns
+	 * a WP_Error simulating HTTP 404 (catalog deleted remotely).
+	 */
+	public function test_find_or_create_falls_back_to_create_on_get_catalog_404(): void {
+		Options::set( OptionDefaults::CATALOG_ID, 'stale-id' );
+
+		$wcs = $this->createMock( WcsClient::class );
+
+		$api = $this->getMockBuilder( CatalogApi::class )
+			->setConstructorArgs( array( $wcs ) )
+			->onlyMethods( array( 'get_catalog', 'create' ) )
+			->getMock();
+
+		$api->expects( $this->once() )
+			->method( 'get_catalog' )
+			->with( 'stale-id' )
+			->willReturn( new WP_Error( 'snapchat_for_woocommerce_request_failed', 'Request failed' ) );
+
+		$create_response = new WP_REST_Response(
+			array(
+				'catalogs' => array(
+					array(
+						'catalog' => array( 'id' => 'fresh-id' ),
+					),
+				),
+			)
+		);
+		$api->expects( $this->once() )->method( 'create' )->willReturn( $create_response );
+
+		$result = $api->find_or_create();
+
+		$this->assertSame( $create_response, $result );
+	}
+
+	/**
+	 * Test: `find_or_create()` falls back to `create()` when `get_catalog()` returns
+	 * a WP_Error from a transient failure (network / auth).
+	 *
+	 * Documents the current "fail-open" behaviour: any WP_Error from `get_catalog()`
+	 * is treated as "missing, create new". If we later decide to fail-closed on
+	 * transient errors, this test will need to be revisited.
+	 */
+	public function test_find_or_create_falls_back_to_create_on_get_catalog_transient_error(): void {
+		Options::set( OptionDefaults::CATALOG_ID, 'existing-id' );
+
+		$wcs = $this->createMock( WcsClient::class );
+
+		$api = $this->getMockBuilder( CatalogApi::class )
+			->setConstructorArgs( array( $wcs ) )
+			->onlyMethods( array( 'get_catalog', 'create' ) )
+			->getMock();
+
+		$api->expects( $this->once() )
+			->method( 'get_catalog' )
+			->with( 'existing-id' )
+			->willReturn( new WP_Error( 'http_request_failed', 'cURL error 28: Operation timed out' ) );
+
+		$create_response = new WP_REST_Response(
+			array(
+				'catalogs' => array(
+					array(
+						'catalog' => array( 'id' => 'new-id' ),
+					),
+				),
+			)
+		);
+		$api->expects( $this->once() )->method( 'create' )->willReturn( $create_response );
+
+		$result = $api->find_or_create();
+
+		$this->assertSame( $create_response, $result );
+	}
+}

--- a/tests/Unit/API/Controllers/SnapchatBusinessExtensionControllerTest.php
+++ b/tests/Unit/API/Controllers/SnapchatBusinessExtensionControllerTest.php
@@ -83,6 +83,7 @@ class SnapchatBusinessExtensionControllerTest extends WP_UnitTestCase {
 		Options::delete( OptionDefaults::ORGANIZATION_NAME );
 		Options::delete( OptionDefaults::AD_ACCOUNT_ID );
 		Options::delete( OptionDefaults::PIXEL_ID );
+		Options::delete( OptionDefaults::CATALOG_ID );
 		Transients::delete( TransientDefaults::PIXEL_SCRIPT );
 		Options::delete( OptionDefaults::ONBOARDING_STATUS );
 
@@ -112,8 +113,9 @@ class SnapchatBusinessExtensionControllerTest extends WP_UnitTestCase {
 		$mock_ad_partner_api = $this->createMock( AdPartnerApi::class );
 		$mock_catalog        = $this->createMock( CatalogApi::class );
 
-		// Mock `create()` to return a mock response with `get_data()`.
-		$mock_catalog->method( 'create' )->willReturn(
+		// `find_or_create()` returns a response shaped like `create()` so
+		// existing assertions keep working after the SNAPWOO-75 fix.
+		$mock_catalog->method( 'find_or_create' )->willReturn(
 			new \WP_REST_Response(
 				array(
 					'catalogs' => array(
@@ -196,5 +198,62 @@ class SnapchatBusinessExtensionControllerTest extends WP_UnitTestCase {
 		$this->assertSame( $this->options['pixel_id'], Options::get( OptionDefaults::PIXEL_ID ) );
 		$this->assertSame( '', Transients::get( TransientDefaults::PIXEL_SCRIPT ) );
 		$this->assertSame( 'connected', Options::get( OptionDefaults::ONBOARDING_STATUS ) );
+	}
+
+	/**
+	 * Test: when a CATALOG_ID is already stored (reconnect scenario), the controller
+	 * reuses it via `find_or_create()` and does NOT call `create()`.
+	 *
+	 * Verifies the fix for SNAPWOO-75: disconnecting and reconnecting must not
+	 * create a duplicate remote catalog on Snapchat's side.
+	 *
+	 * Invokes `set_config()` directly rather than round-tripping through the REST
+	 * server so the `never()` expectation can attach to the specific CatalogApi
+	 * mock wired into the controller under test.
+	 */
+	public function test_set_config_reuses_existing_catalog_id(): void {
+		Options::set( OptionDefaults::CATALOG_ID, 'existing-id' );
+
+		$this->jetpack_client
+			->method( 'remote_request' )
+			->willReturn( array(
+				'response' => array( 'code' => 200, 'message' => 'OK' ),
+				'headers'  => array(),
+				'body'     => file_get_contents( $this->mock_fixture ),
+			) );
+
+		$mock_catalog = $this->createMock( CatalogApi::class );
+		$mock_catalog->method( 'find_or_create' )->willReturn(
+			new \WP_REST_Response(
+				array(
+					'catalogs' => array(
+						array(
+							'catalog' => array( 'id' => 'existing-id' ),
+						),
+					),
+				)
+			)
+		);
+		$mock_catalog->expects( $this->never() )->method( 'create' );
+
+		$wcs = new WcsClient(
+			new JetpackAuthenticator(),
+			$this->jetpack_client
+		);
+		$mock_ad_partner_api          = $this->createMock( AdPartnerApi::class );
+		$mock_ad_partner_api->catalog = $mock_catalog;
+
+		$controller = new SnapchatBusinessExtensionController( $wcs, $mock_ad_partner_api );
+
+		$request = new WP_REST_Request( 'POST', '/wc/sfw/snapchat/config' );
+		$request['id']             = 'hello';
+		$request['products_token'] = 'abc123';
+
+		$response = $controller->set_config( $request );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$data = $response->get_data();
+		$this->assertSame( 'existing-id', $data['catalog_id'] );
+		$this->assertSame( 'existing-id', Options::get( OptionDefaults::CATALOG_ID ) );
 	}
 }


### PR DESCRIPTION
Closes: https://linear.app/a8c/issue/SNAPWOO-75/snap-catalog-enhancement

### Test instructions

* Navigate to WP Admin -> Plugins; ensure Snapchat for WooCommerce is active
* Navigate to WP Admin -> Marketing -> Snapchat; if an account is connected, disconnect it
* Delete existing data:

```
wp option delete snapchat_catalog_id
wp option delete snapchat_organization_id
wp option delete snapchat_pixel_id
```

* Connect to Snapchat through the flow on WP Admin -> Marketing -> Snapchat
* Note the ID's:

```
wp option get snapchat_catalog_id
wp option get snapchat_organization_id
wp option get snapchat_pixel_id
```

* Disconnect Snapchat
* Verify the ID's:
```
wp option get snapchat_catalog_id - should remain and match the value noted prior to disconnect
wp option get snapchat_organization_id - should not exist
wp option get snapchat_pixel_id - should not exist
```

* Reconnect Snapchat - you must use the same account
* Verify the ID's:
```
wp option get snapchat_catalog_id - should still match the existing value noted prior to disconnect
wp option get snapchat_organization_id - should exist, and match the original value noted prior to disconnect
wp option get snapchat_pixel_id - should exist, and match the original value noted prior to disconnect
```


### Changelog entry
> Fix - Ensure the same ID's are used when account is reconnected