### PR TITLE
SNAPWOO-88: Use Flex components for settings layout

### DIFF
--- a/js/src/pages/settings/conversions-api/index.js
+++ b/js/src/pages/settings/conversions-api/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { CheckboxControl } from '@wordpress/components';
+import { CheckboxControl, Flex, FlexBlock } from '@wordpress/components';
 import { useState, useCallback } from '@wordpress/element';
 
 /**
@@ -118,8 +118,11 @@ const ConversionsAPI = () => {
 				'snapchat-for-woocommerce'
 			) }
 			actions={
-				<div className="sfw-settings-track-conversions__actions">
-					<p>
+				<Flex
+					direction="column"
+					className="sfw-settings-track-conversions__actions"
+				>
+					<FlexBlock>
 						<CheckboxControl
 							label={ __(
 								'Enable Conversions API tracking',
@@ -129,9 +132,9 @@ const ConversionsAPI = () => {
 							disabled={ isSaving }
 							onChange={ handleOnChangeOfConversionTracking }
 						/>
-					</p>
+					</FlexBlock>
 
-					<p>
+					<FlexBlock>
 						<CheckboxControl
 							label={ __(
 								'Collect Customer PII',
@@ -145,8 +148,8 @@ const ConversionsAPI = () => {
 								'snapchat-for-woocommerce'
 							) }
 						/>
-					</p>
-				</div>
+					</FlexBlock>
+				</Flex>
 			}
 		/>
 	);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes  https://linear.app/a8c/issue/SNAPWOO-88/bug-nested-p-tag-in-conversions-api-settings

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to the "Settings" page
2. Ensure there's no console warning about `"Warning: validateDOMNesting(...): <div> cannot appear as a descendant of <p>. Error Component Stack"`


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Corrected invalid nested HTML in Conversions API settings.
