### PR TITLE
Record TOS acceptance on connect so onboarding can complete

### DIFF
--- a/includes/API/Site/Controllers/JetpackAccountController.php
+++ b/includes/API/Site/Controllers/JetpackAccountController.php
@@ -123,6 +123,8 @@ class JetpackAccountController extends RESTBaseController {
 				);
 			}
 
+			$this->log_wp_tos_accepted();
+
 			$next     = $request->get_param( 'next_page_name' );
 			$path     = self::NEXT_PATH_MAPPING[ $next ];
 			$redirect = admin_url( "admin.php?page=wc-admin&path={$path}" );


### PR DESCRIPTION
### Problem

`JetpackAccountController::log_wp_tos_accepted()` — the only code that sets `OptionDefaults::WP_TOS_ACCEPTED` to `'yes'` (and notifies WCS via `mark_tos_accepted()`) — is **never called anywhere in the plugin**. `get_connect_callback()` runs `reconnect()/register()` and redirects to the authorization URL without invoking it; the disconnect callback only *deletes* the option.

As a result `wp_tos_accepted` stays `'no'` permanently, onboarding never advances past the `accounts` step, and the product feed never registers. Reconnecting does not help — the OAuth consent screen has no TOS control, and the flag is only ever set by this server-side method.

The sibling `google-listings-and-ads` plugin uses the same controller pattern but **does** call `log_wp_tos_accepted()` in its connect flow — this plugin appears to have inherited the structure without the call. (`reddit-for-woocommerce` does not gate onboarding on a TOS flag, so it is unaffected.)

### Fix

Call `log_wp_tos_accepted()` once a (re)connection succeeds in `get_connect_callback()` — the merchant initiating the connection is the consent action, mirroring `google-listings-and-ads`.

### Testing

Verified on a self-hosted store: with this call in place, a connect records `wp_tos_accepted = 'yes'` and onboarding proceeds past the accounts step.

Opening as a **draft** for the team to confirm the placement/approach (and whether an explicit TOS line in the connect UI is also wanted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
